### PR TITLE
Fix reference handling of captured fence

### DIFF
--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -167,14 +167,24 @@ namespace d3d12hook {
     }
 
     HRESULT STDMETHODCALLTYPE hookSignalD3D12(
-        ID3D12CommandQueue * _this,
-        ID3D12Fence * pFence,
-        UINT64              Value) {
-        if (gCommandQueue && _this == gCommandQueue) {
-            gFence = pFence;
+        ID3D12CommandQueue* _this,
+        ID3D12Fence*        pFence,
+        UINT64              Value)
+    {
+        if (gCommandQueue && _this == gCommandQueue)
+        {
+            if (pFence && pFence != gFence)
+            {
+                if (gFence)
+                    gFence->Release();
+                gFence = pFence;
+                gFence->AddRef();
+            }
+
             gFenceValue = Value;
             DebugLog("[d3d12hook] Captured Fence=%p, Value=%llu\n", pFence, Value);
         }
+
         return oSignalD3D12(_this, pFence, Value);
     }
 
@@ -187,7 +197,11 @@ namespace d3d12hook {
         for (UINT i = 0; i < gBufferCount; ++i) {
             if (gFrameContexts[i].renderTarget) gFrameContexts[i].renderTarget->Release();
         }
-        if (gFence) gFence->Release();
+        if (gFence)
+        {
+            gFence->Release();
+            gFence = nullptr;
+        }
         if (gDevice) gDevice->Release();
         delete[] gFrameContexts;
 


### PR DESCRIPTION
## Summary
- retain a reference to the fence when capturing it
- release the fence safely on shutdown

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_688a62056ee8832493b63f6c5a645df8