### PR TITLE
Handle input hook window and safe removal

### DIFF
--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -255,6 +255,9 @@ namespace d3d12hook {
     void release() {
         DebugLog("[d3d12hook] Releasing resources.\n");
         gShutdown = true;
+        if (globals::mainWindow) {
+            inputhook::Remove(globals::mainWindow);
+        }
         if (gCommandList) gCommandList->Release();
         if (gHeapRTV) gHeapRTV->Release();
         if (gHeapSRV) gHeapSRV->Release();

--- a/inputhooks.cpp
+++ b/inputhooks.cpp
@@ -5,9 +5,16 @@ extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg
 namespace inputhook {
     static WNDPROC sOriginalWndProc = nullptr;
 
+    // Cache the window handle to allow later removal of the hook
+    // (stored in globals::mainWindow for cross-namespace access)
+
     void Init(HWND hWindow)
     {
         DebugLog("[inputhook] Initializing input hook for window %p\n", hWindow);
+
+        // Store window globally for later use during release
+        globals::mainWindow = hWindow;
+
         sOriginalWndProc = (WNDPROC)SetWindowLongPtr(hWindow, GWLP_WNDPROC, (LONG_PTR)WndProc);
         if (!sOriginalWndProc) {
             DebugLog("[inputhook] Failed to set WndProc: %d\n", GetLastError());
@@ -19,6 +26,11 @@ namespace inputhook {
 
     void Remove(HWND hWindow)
     {
+        if (!sOriginalWndProc) {
+            DebugLog("[inputhook] WndProc hook already removed or was never set\n");
+            return;
+        }
+
         DebugLog("[inputhook] Removing input hook for window %p\n", hWindow);
         if (SetWindowLongPtr(hWindow, GWLP_WNDPROC, (LONG_PTR)sOriginalWndProc) == 0) {
             DebugLog("[inputhook] Failed to restore WndProc: %d\n", GetLastError());
@@ -26,6 +38,10 @@ namespace inputhook {
         else {
             DebugLog("[inputhook] WndProc restored to %p\n", sOriginalWndProc);
         }
+
+        // Clear cached values to prevent repeated removals
+        sOriginalWndProc = nullptr;
+        globals::mainWindow = nullptr;
     }
 
     LRESULT APIENTRY WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)


### PR DESCRIPTION
## Summary
- Track the window handle passed to `inputhook::Init` in a global so it can be released later
- Remove the input hook using the stored window during `d3d12hook::release`
- Guard `inputhook::Remove` against repeated calls after the hook is gone

## Testing
- `g++ -std=c++17 -c inputhooks.cpp` *(fails: windows.h: No such file or directory)*
- `apt-get update` *(fails: repository is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4730b0f248324bd5b4c1a27a7d57d