### PR TITLE
Shutdown ImGui before disabling D3D12 hooks

### DIFF
--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -287,6 +287,12 @@ namespace d3d12hook {
         if (globals::mainWindow) {
             inputhook::Remove(globals::mainWindow);
         }
+
+        // Shutdown ImGui before releasing any D3D resources
+        ImGui_ImplDX12_Shutdown();
+        ImGui_ImplWin32_Shutdown();
+        ImGui::DestroyContext();
+
         if (gCommandList) gCommandList->Release();
         if (gHeapRTV) gHeapRTV->Release();
         if (gHeapSRV) gHeapSRV->Release();


### PR DESCRIPTION
## Summary
- Shutdown ImGui's DX12 and Win32 backends and destroy the context during `release` so resources are freed before unhooking

## Testing
- ⚠️ `msbuild Universal-ImGui-Hook.sln` *(command not found)*
- ⚠️ `g++ -c d3d12hook.cpp -Iimgui -Iimgui/backends -Iminhook/include` *(missing Windows headers)*

------
https://chatgpt.com/codex/tasks/task_e_68a475685264832495ffad99bd3f74e2