### PR TITLE
Call original ExecuteCommandLists in present hook

### DIFF
--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -179,7 +179,7 @@ namespace d3d12hook {
                 DebugLog("[d3d12hook] CommandQueue not set, skipping ExecuteCommandLists.\n");
             }
             else {
-                gCommandQueue->ExecuteCommandLists(1, reinterpret_cast<ID3D12CommandList* const*>(&gCommandList));
+                oExecuteCommandListsD3D12(gCommandQueue, 1, reinterpret_cast<ID3D12CommandList* const*>(&gCommandList));
                 if (gFence) {
                     HRESULT hr = gCommandQueue->Signal(gFence, ++gFenceValue);
                     if (FAILED(hr)) {


### PR DESCRIPTION
## Summary
- Call the original `ExecuteCommandLists` inside the D3D12 `Present` hook

## Testing
- `g++ -std=c++17 -c d3d12hook.cpp -o /tmp/d3d12hook.o` *(fails: windows.h: No such file or directory)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a47687d1b48324b803474719b7b9f3