### PR TITLE
Fix vtable pointer types for Windows hooks

### DIFF
--- a/hooks.cpp
+++ b/hooks.cpp
@@ -128,7 +128,7 @@ namespace hooks {
         MH_STATUS mh;
 
         // --- Hook Present on SwapChain ---
-        auto scVTable = *reinterpret_cast<uintptr_t**>(pSwapChain.Get());
+        auto scVTable = *reinterpret_cast<void***>(pSwapChain.Get());
         if (scVTable[kPresentIndex] != GetAddress(&IDXGISwapChain3::Present))
             DebugLog("[hooks] Warning: Present index %zu may be incorrect\n", kPresentIndex);
         if (scVTable[kResizeBuffersIndex] != GetAddress(&IDXGISwapChain3::ResizeBuffers))
@@ -151,7 +151,7 @@ namespace hooks {
             DebugLog("[hooks] MH_CreateHook ResizeBuffers failed: %s\n", MH_StatusToString(mh));
 
         // --- Hook ExecuteCommandLists ---
-        auto cqVTable = *reinterpret_cast<uintptr_t**>(pCommandQueue.Get());
+        auto cqVTable = *reinterpret_cast<void***>(pCommandQueue.Get());
         if (cqVTable[kExecuteCommandListsIndex] != GetAddress(&ID3D12CommandQueue::ExecuteCommandLists))
             DebugLog("[hooks] Warning: ExecuteCommandLists index %zu may be incorrect\n", kExecuteCommandListsIndex);
         if (cqVTable[kSignalIndex] != GetAddress(&ID3D12CommandQueue::Signal))


### PR DESCRIPTION
## Summary
- Use `void*` for swap chain and command queue vtable pointers
- Avoid pointer-int comparisons in hook setup

## Testing
- `g++ -std=c++17 -c hooks.cpp` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a478678d248324bb2a0b0259b1755e