### PR TITLE
Use reinterpret_cast for vtable indices and remove constexpr

### DIFF
--- a/hooks.cpp
+++ b/hooks.cpp
@@ -4,21 +4,19 @@ using Microsoft::WRL::ComPtr;
 
 namespace hooks {
     template<typename T, typename M>
-    static constexpr size_t GetIndex(M T::* method) {
-        union { M T::* m; size_t i; } caster{ method };
-        return caster.i / sizeof(void*);
+    static size_t GetIndex(M T::* method) {
+        return reinterpret_cast<size_t&>(method) / sizeof(void*);
     }
 
     template<typename T, typename M>
-    static constexpr void* GetAddress(M T::* method) {
-        union { M T::* m; void* addr; } caster{ method };
-        return caster.addr;
+    static void* GetAddress(M T::* method) {
+        return reinterpret_cast<void*&>(method);
     }
 
-    static constexpr size_t kPresentIndex = GetIndex(&IDXGISwapChain3::Present);
-    static constexpr size_t kResizeBuffersIndex = GetIndex(&IDXGISwapChain3::ResizeBuffers);
-    static constexpr size_t kExecuteCommandListsIndex = GetIndex(&ID3D12CommandQueue::ExecuteCommandLists);
-    static constexpr size_t kSignalIndex = GetIndex(&ID3D12CommandQueue::Signal);
+    static size_t kPresentIndex = GetIndex(&IDXGISwapChain3::Present);
+    static size_t kResizeBuffersIndex = GetIndex(&IDXGISwapChain3::ResizeBuffers);
+    static size_t kExecuteCommandListsIndex = GetIndex(&ID3D12CommandQueue::ExecuteCommandLists);
+    static size_t kSignalIndex = GetIndex(&ID3D12CommandQueue::Signal);
     // Dummy objects pour extraire les v-tables
     static ComPtr<IDXGISwapChain3>       pSwapChain = nullptr;
     static ComPtr<ID3D12Device>          pDevice = nullptr;


### PR DESCRIPTION
## Summary
- replace union-based member pointer casts with reinterpret_cast
- remove constexpr from helper functions and index constants

## Testing
- `g++ -std=c++17 -c hooks.cpp` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a482acd4a8832483b153067aadbea2