### PR TITLE
Call MH_RemoveHook during D3D12 hook release

### DIFF
--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -316,7 +316,16 @@ namespace d3d12hook {
         delete[] gFrameContexts;
 
         // Unhook
-        MH_DisableHook(MH_ALL_HOOKS);
-        DebugLog("[d3d12hook] Hooks disabled.\n");
+        MH_STATUS mh = MH_DisableHook(MH_ALL_HOOKS);
+        if (mh != MH_OK)
+            DebugLog("[d3d12hook] MH_DisableHook failed: %s\n", MH_StatusToString(mh));
+        else
+            DebugLog("[d3d12hook] Hooks disabled.\n");
+
+        mh = MH_RemoveHook(MH_ALL_HOOKS);
+        if (mh != MH_OK)
+            DebugLog("[d3d12hook] MH_RemoveHook failed: %s\n", MH_StatusToString(mh));
+        else
+            DebugLog("[d3d12hook] Hooks removed.\n");
     }
 }


### PR DESCRIPTION
## Summary
- ensure MH_RemoveHook is called after disabling hooks
- log MinHook disable/remove errors

## Testing
- `g++ -std=c++17 -c d3d12hook.cpp` *(fails: windows.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4843b5e0883249b0af96e9ddb74bd