### PR TITLE
Streamline hook cleanup in detach sequence

### DIFF
--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -294,7 +294,7 @@ namespace d3d12hook {
     }
 
     void release() {
-        DebugLog("[d3d12hook] Releasing resources.\n");
+        DebugLog("[d3d12hook] Releasing resources and hooks.\n");
         gShutdown = true;
         if (globals::mainWindow) {
             inputhook::Remove(globals::mainWindow);

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -44,13 +44,13 @@ BOOL WINAPI DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved
         break;
 
     case DLL_PROCESS_DETACH:
-        DebugLog("[DllMain] DLL_PROCESS_DETACH. Uninitializing hooks.\n");
+        DebugLog("[DllMain] DLL_PROCESS_DETACH. Releasing hooks and uninitializing MinHook.\n");
         // Release DirectX resources and hooks
         d3d12hook::release();
 
-        // Disable all hooks and uninitialize MinHook
-        MH_DisableHook(MH_ALL_HOOKS);
+        // Uninitialize MinHook
         MH_Uninitialize();
+        DebugLog("[DllMain] MinHook uninitialized.\n");
         break;
     }
     return TRUE;


### PR DESCRIPTION
## Summary
- centralize hook release logic inside `d3d12hook::release`
- update detach logs to reflect new cleanup flow

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a68e5f548324a928eb674189ab08