### PR TITLE
Reset ImGui and input hooks on D3D12 resize

### DIFF
--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -255,6 +255,11 @@ namespace d3d12hook {
         {
             DebugLog("[d3d12hook] Releasing resources for resize\n");
 
+            ImGui_ImplDX12_Shutdown();
+            ImGui_ImplWin32_Shutdown();
+            ImGui::DestroyContext();
+            inputhook::Remove(globals::mainWindow);
+
             if (gCommandList)
             {
                 gCommandList->Release();


### PR DESCRIPTION
## Summary
- Shutdown ImGui and input hooks before releasing resources on swap chain resize
- Leave resize handling to reinitialize cleanly on next Present

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ab9c74b88324b044be6360a0b2df