### PR TITLE
Detect active graphics backend on attach

### DIFF
--- a/globals.cpp
+++ b/globals.cpp
@@ -9,12 +9,15 @@ namespace globals {
     int uninjectKey = VK_F12;
     // Key to open/close the ImGui menu (INSERT by default)
     int openMenuKey = VK_INSERT;
+    // Currently active rendering backend
+    Backend activeBackend = Backend::None;
 }
 
 // Log initial global values for debugging
 static void LogGlobals() {
-    DebugLog("[Globals] mainModule=%p, mainWindow=%p, uninjectKey=0x%X, openMenuKey=0x%X\n",
-        globals::mainModule, globals::mainWindow, globals::uninjectKey, globals::openMenuKey);
+    DebugLog("[Globals] mainModule=%p, mainWindow=%p, uninjectKey=0x%X, openMenuKey=0x%X, backend=%d\n",
+        globals::mainModule, globals::mainWindow, globals::uninjectKey, globals::openMenuKey,
+        static_cast<int>(globals::activeBackend));
 }
 
 // Ensure we log when the DLL is loaded

--- a/namespaces.h
+++ b/namespaces.h
@@ -1,14 +1,25 @@
 #pragma once
 
 namespace globals {
-	extern HMODULE mainModule;
-	extern HWND mainWindow;
-	extern int uninjectKey;
-	extern int openMenuKey;
+        extern HMODULE mainModule;
+        extern HWND mainWindow;
+        extern int uninjectKey;
+        extern int openMenuKey;
+
+        // Rendering backend currently in use
+        enum class Backend {
+                None,
+                DX9,
+                DX10,
+                DX11,
+                DX12,
+                Vulkan
+        };
+        extern Backend activeBackend;
 }
 
 namespace hooks {
-	extern void Init();
+        extern void Init();
 }
 
 namespace inputhook {
@@ -58,7 +69,25 @@ namespace d3d12hook {
 		ID3D12Fence* pFence,
 		UINT64              Value);
 
-	extern void release();
+        extern void release();
+}
+
+// Forward declarations for other rendering backends
+namespace hooks_dx9 {
+        void Init();
+        void release();
+}
+namespace hooks_dx10 {
+        void Init();
+        void release();
+}
+namespace hooks_dx11 {
+        void Init();
+        void release();
+}
+namespace hooks_vk {
+        void Init();
+        void release();
 }
 
 namespace menu {


### PR DESCRIPTION
## Summary
- detect loaded graphics modules (d3d9, d3d10, d3d11, d3d12/dxgi, vulkan) and run matching hook init
- track active backend globally to release correct resources on detach
- add forward declarations for backend-specific hook namespaces

## Testing
- `x86_64-w64-mingw32-g++ -v` *(fails: command not found)*
- `g++ -c dllmain.cpp` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b49438048324843f256d1e0a57ac