### PR TITLE
Add Direct3D9 ImGui hook

### DIFF
--- a/Universal-ImGui-Hook.vcxproj
+++ b/Universal-ImGui-Hook.vcxproj
@@ -120,6 +120,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="d3d9hook.cpp" />
     <ClCompile Include="d3d12hook.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="globals.cpp" />
@@ -128,6 +129,7 @@
     <ClCompile Include="imgui\imgui_demo.cpp" />
     <ClCompile Include="imgui\imgui_draw.cpp" />
     <ClCompile Include="imgui\imgui_impl_dx12.cpp" />
+    <ClCompile Include="imgui\\backends\\imgui_impl_dx9.cpp" />
     <ClCompile Include="imgui\imgui_impl_win32.cpp" />
     <ClCompile Include="imgui\imgui_tables.cpp" />
     <ClCompile Include="imgui\imgui_widgets.cpp" />
@@ -138,11 +140,13 @@
     <ClInclude Include="imgui\imconfig.h" />
     <ClInclude Include="imgui\imgui.h" />
     <ClInclude Include="imgui\imgui_impl_dx12.h" />
+    <ClInclude Include="imgui\\backends\\imgui_impl_dx9.h" />
     <ClInclude Include="imgui\imgui_impl_win32.h" />
     <ClInclude Include="imgui\imgui_internal.h" />
     <ClInclude Include="imgui\imstb_rectpack.h" />
     <ClInclude Include="imgui\imstb_textedit.h" />
     <ClInclude Include="imgui\imstb_truetype.h" />
+    <ClInclude Include="d3d9hook.h" />
     <ClInclude Include="namespaces.h" />
     <ClInclude Include="stdafx.h" />
   </ItemGroup>

--- a/Universal-ImGui-Hook.vcxproj.filters
+++ b/Universal-ImGui-Hook.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="imgui\imgui_impl_dx12.cpp">
       <Filter>Sources Files\imgui</Filter>
     </ClCompile>
+    <ClCompile Include="imgui\backends\imgui_impl_dx9.cpp">
+      <Filter>Sources Files\imgui</Filter>
+    </ClCompile>
     <ClCompile Include="imgui\imgui_impl_win32.cpp">
       <Filter>Sources Files\imgui</Filter>
     </ClCompile>
@@ -49,6 +52,9 @@
       <Filter>Sources Files</Filter>
     </ClCompile>
     <ClCompile Include="d3d12hook.cpp">
+      <Filter>Sources Files</Filter>
+    </ClCompile>
+    <ClCompile Include="d3d9hook.cpp">
       <Filter>Sources Files</Filter>
     </ClCompile>
     <ClCompile Include="menu.cpp">
@@ -68,6 +74,9 @@
     <ClInclude Include="imgui\imgui_impl_dx12.h">
       <Filter>Sources Files\imgui</Filter>
     </ClInclude>
+    <ClInclude Include="imgui\backends\imgui_impl_dx9.h">
+      <Filter>Sources Files\imgui</Filter>
+    </ClInclude>
     <ClInclude Include="imgui\imgui_impl_win32.h">
       <Filter>Sources Files\imgui</Filter>
     </ClInclude>
@@ -82,6 +91,9 @@
     </ClInclude>
     <ClInclude Include="imgui\imstb_truetype.h">
       <Filter>Sources Files\imgui</Filter>
+    </ClInclude>
+    <ClInclude Include="d3d9hook.h">
+      <Filter>Sources Files</Filter>
     </ClInclude>
     <ClInclude Include="stdafx.h">
       <Filter>Sources Files</Filter>

--- a/d3d9hook.cpp
+++ b/d3d9hook.cpp
@@ -1,0 +1,116 @@
+#include "stdafx.h"
+#include <d3d9.h>
+#include "imgui/backends/imgui_impl_dx9.h"
+#include "d3d9hook.h"
+
+#pragma comment(lib, "d3d9.lib")
+
+namespace d3d9hook {
+    EndSceneFn oEndScene = nullptr;
+    ResetFn    oReset    = nullptr;
+
+    static bool gInitialized = false;
+
+    HRESULT __stdcall hookEndScene(IDirect3DDevice9* device) {
+        if (!gInitialized) {
+            D3DDEVICE_CREATION_PARAMETERS params{};
+            if (SUCCEEDED(device->GetCreationParameters(&params))) {
+                ImGui::CreateContext();
+                ImGuiIO& io = ImGui::GetIO(); (void)io;
+                io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+                ImGui::StyleColorsDark();
+                ImGui_ImplWin32_Init(params.hFocusWindow);
+                ImGui_ImplDX9_Init(device);
+                inputhook::Init(params.hFocusWindow);
+                gInitialized = true;
+                DebugLog("[d3d9hook] ImGui initialized on EndScene.\\n");
+            }
+        }
+
+        if (GetAsyncKeyState(globals::openMenuKey) & 1) {
+            menu::isOpen = !menu::isOpen;
+            DebugLog("[d3d9hook] Toggle menu: %d\\n", menu::isOpen);
+        }
+
+        if (gInitialized) {
+            ImGui_ImplDX9_NewFrame();
+            ImGui_ImplWin32_NewFrame();
+            ImGui::NewFrame();
+            if (menu::isOpen) {
+                menu::Init();
+            }
+            ImGui::EndFrame();
+            ImGui::Render();
+            ImGui_ImplDX9_RenderDrawData(ImGui::GetDrawData());
+        }
+
+        return oEndScene(device);
+    }
+
+    HRESULT __stdcall hookReset(IDirect3DDevice9* device, D3DPRESENT_PARAMETERS* params) {
+        if (gInitialized) {
+            ImGui_ImplDX9_InvalidateDeviceObjects();
+        }
+        HRESULT hr = oReset(device, params);
+        if (gInitialized) {
+            ImGui_ImplDX9_CreateDeviceObjects();
+        }
+        return hr;
+    }
+
+    void Init() {
+        DebugLog("[d3d9hook] Init starting\\n");
+        IDirect3D9* d3d = Direct3DCreate9(D3D_SDK_VERSION);
+        if (!d3d) {
+            DebugLog("[d3d9hook] Direct3DCreate9 failed\\n");
+            return;
+        }
+
+        WNDCLASSEX wc{ sizeof(WNDCLASSEX), CS_CLASSDC, DefWindowProc, 0L, 0L,
+            GetModuleHandle(nullptr), nullptr, nullptr, nullptr, nullptr,
+            L"DummyD3D9", nullptr };
+        RegisterClassEx(&wc);
+        HWND hwnd = CreateWindow(wc.lpszClassName, L"", WS_OVERLAPPEDWINDOW,
+            0, 0, 100, 100, nullptr, nullptr, wc.hInstance, nullptr);
+
+        D3DPRESENT_PARAMETERS d3dpp{};
+        d3dpp.Windowed = TRUE;
+        d3dpp.SwapEffect = D3DSWAPEFFECT_DISCARD;
+        d3dpp.hDeviceWindow = hwnd;
+
+        IDirect3DDevice9* device = nullptr;
+        HRESULT hr = d3d->CreateDevice(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, hwnd,
+            D3DCREATE_SOFTWARE_VERTEXPROCESSING, &d3dpp, &device);
+        if (SUCCEEDED(hr)) {
+            void** vtbl = *reinterpret_cast<void***>(device);
+            MH_CreateHook(vtbl[42], reinterpret_cast<void*>(hookEndScene), reinterpret_cast<void**>(&oEndScene));
+            MH_CreateHook(vtbl[16], reinterpret_cast<void*>(hookReset), reinterpret_cast<void**>(&oReset));
+            MH_EnableHook(vtbl[42]);
+            MH_EnableHook(vtbl[16]);
+            DebugLog("[d3d9hook] Hooks placed EndScene@%p Reset@%p\\n", vtbl[42], vtbl[16]);
+            device->Release();
+        } else {
+            DebugLog("[d3d9hook] CreateDevice failed: 0x%08X\\n", hr);
+        }
+
+        DestroyWindow(hwnd);
+        UnregisterClass(wc.lpszClassName, wc.hInstance);
+        d3d->Release();
+    }
+
+    void release() {
+        DebugLog("[d3d9hook] Releasing resources\\n");
+        if (globals::mainWindow) {
+            inputhook::Remove(globals::mainWindow);
+        }
+        if (gInitialized) {
+            ImGui_ImplDX9_Shutdown();
+            ImGui_ImplWin32_Shutdown();
+            ImGui::DestroyContext();
+            gInitialized = false;
+        }
+        MH_DisableHook(MH_ALL_HOOKS);
+        MH_RemoveHook(MH_ALL_HOOKS);
+        MH_Uninitialize();
+    }
+}

--- a/d3d9hook.h
+++ b/d3d9hook.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <d3d9.h>
+
+namespace d3d9hook {
+    using EndSceneFn = HRESULT(__stdcall*)(IDirect3DDevice9*);
+    using ResetFn    = HRESULT(__stdcall*)(IDirect3DDevice9*, D3DPRESENT_PARAMETERS*);
+
+    extern EndSceneFn oEndScene;
+    extern ResetFn    oReset;
+
+    HRESULT __stdcall hookEndScene(IDirect3DDevice9* device);
+    HRESULT __stdcall hookReset(IDirect3DDevice9* device, D3DPRESENT_PARAMETERS* params);
+
+    void Init();
+    void release();
+}

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -20,7 +20,7 @@ static DWORD WINAPI onAttach(LPVOID lpParameter)
     HMODULE mod = nullptr;
     if ((mod = GetModuleHandleA("d3d9.dll"))) {
         DebugLog("[DllMain] Detected d3d9.dll (%p). Initializing DX9 hooks.\n", mod);
-        hooks_dx9::Init();
+        d3d9hook::Init();
         globals::activeBackend = globals::Backend::DX9;
     }
     else if ((mod = GetModuleHandleA("d3d10.dll"))) {
@@ -75,7 +75,7 @@ BOOL WINAPI DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved
         DebugLog("[DllMain] DLL_PROCESS_DETACH. Releasing hooks and uninitializing MinHook.\n");
         switch (globals::activeBackend) {
         case globals::Backend::DX9:
-            hooks_dx9::release();
+            d3d9hook::release();
             break;
         case globals::Backend::DX10:
             hooks_dx10::release();

--- a/namespaces.h
+++ b/namespaces.h
@@ -73,7 +73,7 @@ namespace d3d12hook {
 }
 
 // Forward declarations for other rendering backends
-namespace hooks_dx9 {
+namespace d3d9hook {
         void Init();
         void release();
 }


### PR DESCRIPTION
## Summary
- add d3d9 hook with MinHook EndScene/Reset interception
- init ImGui for DX9/Win32 and render menu
- integrate release and project files

## Testing
- `g++ -std=c++17 -c d3d9hook.cpp` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b5a2f64c8324804eaafa03040e5b