### PR TITLE
Add DirectX 10 swap chain hooks

### DIFF
--- a/Universal-ImGui-Hook.vcxproj
+++ b/Universal-ImGui-Hook.vcxproj
@@ -121,6 +121,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="d3d9hook.cpp" />
+    <ClCompile Include="d3d10hook.cpp" />
     <ClCompile Include="d3d12hook.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="globals.cpp" />
@@ -130,6 +131,7 @@
     <ClCompile Include="imgui\imgui_draw.cpp" />
     <ClCompile Include="imgui\imgui_impl_dx12.cpp" />
     <ClCompile Include="imgui\\backends\\imgui_impl_dx9.cpp" />
+    <ClCompile Include="imgui\\backends\\imgui_impl_dx10.cpp" />
     <ClCompile Include="imgui\imgui_impl_win32.cpp" />
     <ClCompile Include="imgui\imgui_tables.cpp" />
     <ClCompile Include="imgui\imgui_widgets.cpp" />
@@ -141,12 +143,14 @@
     <ClInclude Include="imgui\imgui.h" />
     <ClInclude Include="imgui\imgui_impl_dx12.h" />
     <ClInclude Include="imgui\\backends\\imgui_impl_dx9.h" />
+    <ClInclude Include="imgui\\backends\\imgui_impl_dx10.h" />
     <ClInclude Include="imgui\imgui_impl_win32.h" />
     <ClInclude Include="imgui\imgui_internal.h" />
     <ClInclude Include="imgui\imstb_rectpack.h" />
     <ClInclude Include="imgui\imstb_textedit.h" />
     <ClInclude Include="imgui\imstb_truetype.h" />
     <ClInclude Include="d3d9hook.h" />
+    <ClInclude Include="d3d10hook.h" />
     <ClInclude Include="namespaces.h" />
     <ClInclude Include="stdafx.h" />
   </ItemGroup>

--- a/Universal-ImGui-Hook.vcxproj.filters
+++ b/Universal-ImGui-Hook.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="imgui\imgui_impl_win32.cpp">
       <Filter>Sources Files\imgui</Filter>
     </ClCompile>
+    <ClCompile Include="imgui\backends\imgui_impl_dx10.cpp">
+      <Filter>Sources Files\imgui</Filter>
+    </ClCompile>
     <ClCompile Include="imgui\imgui_tables.cpp">
       <Filter>Sources Files\imgui</Filter>
     </ClCompile>
@@ -52,6 +55,9 @@
       <Filter>Sources Files</Filter>
     </ClCompile>
     <ClCompile Include="d3d12hook.cpp">
+      <Filter>Sources Files</Filter>
+    </ClCompile>
+    <ClCompile Include="d3d10hook.cpp">
       <Filter>Sources Files</Filter>
     </ClCompile>
     <ClCompile Include="d3d9hook.cpp">
@@ -80,6 +86,9 @@
     <ClInclude Include="imgui\imgui_impl_win32.h">
       <Filter>Sources Files\imgui</Filter>
     </ClInclude>
+    <ClInclude Include="imgui\backends\imgui_impl_dx10.h">
+      <Filter>Sources Files\imgui</Filter>
+    </ClInclude>
     <ClInclude Include="imgui\imgui_internal.h">
       <Filter>Sources Files\imgui</Filter>
     </ClInclude>
@@ -93,6 +102,9 @@
       <Filter>Sources Files\imgui</Filter>
     </ClInclude>
     <ClInclude Include="d3d9hook.h">
+      <Filter>Sources Files</Filter>
+    </ClInclude>
+    <ClInclude Include="d3d10hook.h">
       <Filter>Sources Files</Filter>
     </ClInclude>
     <ClInclude Include="stdafx.h">

--- a/d3d10hook.cpp
+++ b/d3d10hook.cpp
@@ -1,0 +1,180 @@
+#include "stdafx.h"
+#include <d3d10.h>
+#include "imgui/backends/imgui_impl_dx10.h"
+#pragma comment(lib, "d3d10.lib")
+
+namespace hooks_dx10 {
+    using Microsoft::WRL::ComPtr;
+
+    PresentFn       oPresentD3D10 = nullptr;
+    ResizeBuffersFn oResizeBuffersD3D10 = nullptr;
+
+    static ID3D10Device*           gDevice = nullptr;
+    static IDXGISwapChain*         gSwapChain = nullptr;
+    static ID3D10RenderTargetView* gRTV = nullptr;
+    static bool                    gInitialized = false;
+
+    static void CreateRenderTarget()
+    {
+        ID3D10Texture2D* pBackBuffer = nullptr;
+        if (gSwapChain && SUCCEEDED(gSwapChain->GetBuffer(0, IID_PPV_ARGS(&pBackBuffer))))
+        {
+            gDevice->CreateRenderTargetView(pBackBuffer, nullptr, &gRTV);
+            pBackBuffer->Release();
+        }
+    }
+
+    static void CleanupRenderTarget()
+    {
+        if (gRTV)
+        {
+            gRTV->Release();
+            gRTV = nullptr;
+        }
+    }
+
+    HRESULT __stdcall hookPresentD3D10(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags)
+    {
+        if (!gInitialized)
+        {
+            gSwapChain = pSwapChain;
+            if (SUCCEEDED(pSwapChain->GetDevice(__uuidof(ID3D10Device), (void**)&gDevice)))
+            {
+                DXGI_SWAP_CHAIN_DESC desc{};
+                pSwapChain->GetDesc(&desc);
+
+                ImGui::CreateContext();
+                ImGuiIO& io = ImGui::GetIO(); (void)io;
+                io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+                ImGui::StyleColorsDark();
+                ImGui_ImplWin32_Init(desc.OutputWindow);
+                ImGui_ImplDX10_Init(gDevice);
+                inputhook::Init(desc.OutputWindow);
+                CreateRenderTarget();
+                gInitialized = true;
+                DebugLog("[d3d10hook] ImGui initialized.\n");
+            }
+        }
+
+        if (GetAsyncKeyState(globals::openMenuKey) & 1)
+        {
+            menu::isOpen = !menu::isOpen;
+            DebugLog("[d3d10hook] Toggle menu: %d\n", menu::isOpen);
+        }
+
+        if (gInitialized)
+        {
+            ImGui_ImplDX10_NewFrame();
+            ImGui_ImplWin32_NewFrame();
+            ImGui::NewFrame();
+            if (menu::isOpen)
+                menu::Init();
+            ImGui::EndFrame();
+            ImGui::Render();
+            gDevice->OMSetRenderTargets(1, &gRTV, nullptr);
+            ImGui_ImplDX10_RenderDrawData(ImGui::GetDrawData());
+        }
+
+        return oPresentD3D10(pSwapChain, SyncInterval, Flags);
+    }
+
+    HRESULT __stdcall hookResizeBuffersD3D10(
+        IDXGISwapChain* pSwapChain,
+        UINT BufferCount,
+        UINT Width,
+        UINT Height,
+        DXGI_FORMAT NewFormat,
+        UINT SwapChainFlags)
+    {
+        if (gInitialized)
+        {
+            ImGui_ImplDX10_InvalidateDeviceObjects();
+            CleanupRenderTarget();
+        }
+
+        HRESULT hr = oResizeBuffersD3D10(pSwapChain, BufferCount, Width, Height, NewFormat, SwapChainFlags);
+
+        if (gInitialized)
+        {
+            CreateRenderTarget();
+            ImGui_ImplDX10_CreateDeviceObjects();
+        }
+
+        return hr;
+    }
+
+    void Init()
+    {
+        DebugLog("[d3d10hook] Init starting\n");
+
+        WNDCLASSEXW wc = {
+            sizeof(WNDCLASSEXW), CS_CLASSDC, DefWindowProcW,
+            0L, 0L, GetModuleHandleW(nullptr), nullptr, nullptr, nullptr, nullptr,
+            L"DummyDX10", nullptr
+        };
+        RegisterClassExW(&wc);
+        HWND hwnd = CreateWindowW(wc.lpszClassName, L"", WS_OVERLAPPEDWINDOW,
+            0, 0, 100, 100, nullptr, nullptr, wc.hInstance, nullptr);
+
+        DXGI_SWAP_CHAIN_DESC sd{};
+        sd.BufferCount = 2;
+        sd.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        sd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        sd.OutputWindow = hwnd;
+        sd.SampleDesc.Count = 1;
+        sd.Windowed = TRUE;
+        sd.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
+
+        ID3D10Device* device = nullptr;
+        IDXGISwapChain* swapChain = nullptr;
+        HRESULT hr = D3D10CreateDeviceAndSwapChain(
+            nullptr, D3D10_DRIVER_TYPE_HARDWARE, nullptr, 0,
+            D3D10_SDK_VERSION, &sd, &swapChain, &device);
+
+        if (SUCCEEDED(hr))
+        {
+            void** vtbl = *reinterpret_cast<void***>(swapChain);
+            MH_CreateHook(vtbl[8], hookPresentD3D10, reinterpret_cast<void**>(&oPresentD3D10));
+            MH_CreateHook(vtbl[13], hookResizeBuffersD3D10, reinterpret_cast<void**>(&oResizeBuffersD3D10));
+            MH_EnableHook(vtbl[8]);
+            MH_EnableHook(vtbl[13]);
+            DebugLog("[d3d10hook] Hooks placed Present@%p ResizeBuffers@%p\n", vtbl[8], vtbl[13]);
+            swapChain->Release();
+            device->Release();
+        }
+        else
+        {
+            DebugLog("[d3d10hook] D3D10CreateDeviceAndSwapChain failed: 0x%08X\n", hr);
+        }
+
+        DestroyWindow(hwnd);
+        UnregisterClassW(wc.lpszClassName, wc.hInstance);
+    }
+
+    void release()
+    {
+        DebugLog("[d3d10hook] Releasing resources\n");
+
+        if (globals::mainWindow)
+            inputhook::Remove(globals::mainWindow);
+
+        if (gInitialized)
+        {
+            ImGui_ImplDX10_Shutdown();
+            ImGui_ImplWin32_Shutdown();
+            ImGui::DestroyContext();
+            CleanupRenderTarget();
+            if (gDevice)
+            {
+                gDevice->Release();
+                gDevice = nullptr;
+            }
+            gSwapChain = nullptr;
+            gInitialized = false;
+        }
+
+        MH_DisableHook(MH_ALL_HOOKS);
+        MH_RemoveHook(MH_ALL_HOOKS);
+        MH_Uninitialize();
+    }
+}

--- a/d3d10hook.h
+++ b/d3d10hook.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <d3d10.h>
+#include <dxgi.h>
+
+namespace hooks_dx10 {
+    using PresentFn = HRESULT(__stdcall*)(IDXGISwapChain*, UINT, UINT);
+    using ResizeBuffersFn = HRESULT(__stdcall*)(IDXGISwapChain*, UINT, UINT, UINT, DXGI_FORMAT, UINT);
+
+    extern PresentFn       oPresentD3D10;
+    extern ResizeBuffersFn oResizeBuffersD3D10;
+
+    HRESULT __stdcall hookPresentD3D10(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags);
+    HRESULT __stdcall hookResizeBuffersD3D10(
+        IDXGISwapChain* pSwapChain,
+        UINT BufferCount,
+        UINT Width,
+        UINT Height,
+        DXGI_FORMAT NewFormat,
+        UINT SwapChainFlags);
+
+    void Init();
+    void release();
+}


### PR DESCRIPTION
## Summary
- intercept IDXGISwapChain::Present and ResizeBuffers for DirectX 10
- bootstrap hooks via dummy D3D10 device and initialize ImGui with ImGui_ImplDX10_Init
- include DX10 backend sources in project and ensure proper cleanup on unload

## Testing
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68a5b7bbaa108324add33b8542aeda81