### PR TITLE
Add DirectX 11 hook and project wiring

### DIFF
--- a/Universal-ImGui-Hook.vcxproj
+++ b/Universal-ImGui-Hook.vcxproj
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<?xml version='1.0' encoding='utf-8'?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build" ToolsVersion="15.0">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -122,6 +122,7 @@
   <ItemGroup>
     <ClCompile Include="d3d9hook.cpp" />
     <ClCompile Include="d3d10hook.cpp" />
+    <ClCompile Include="d3d11hook.cpp" />
     <ClCompile Include="d3d12hook.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="globals.cpp" />
@@ -137,8 +138,10 @@
     <ClCompile Include="imgui\imgui_widgets.cpp" />
     <ClCompile Include="inputhooks.cpp" />
     <ClCompile Include="menu.cpp" />
+    <ClCompile Include="imgui\backends\imgui_impl_dx11.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="imgui\backends\imgui_impl_dx11.h" />
     <ClInclude Include="imgui\imconfig.h" />
     <ClInclude Include="imgui\imgui.h" />
     <ClInclude Include="imgui\imgui_impl_dx12.h" />
@@ -151,6 +154,7 @@
     <ClInclude Include="imgui\imstb_truetype.h" />
     <ClInclude Include="d3d9hook.h" />
     <ClInclude Include="d3d10hook.h" />
+    <ClInclude Include="d3d11hook.h" />
     <ClInclude Include="namespaces.h" />
     <ClInclude Include="stdafx.h" />
   </ItemGroup>

--- a/Universal-ImGui-Hook.vcxproj.filters
+++ b/Universal-ImGui-Hook.vcxproj.filters
@@ -1,133 +1,407 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<?xml version="1.0" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  
+  
   <ItemGroup>
+    
+    
     <Filter Include="Sources Files">
+      
+      
       <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      
+      
       <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+      
+    
     </Filter>
+    
+    
     <Filter Include="Headers Files">
+      
+      
       <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      
+      
       <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+      
+    
     </Filter>
+    
+    
     <Filter Include="Resources Files">
+      
+      
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      
+      
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+      
+    
     </Filter>
+    
+    
     <Filter Include="Sources Files\imgui">
+      
+      
       <UniqueIdentifier>{962e4318-7c4d-4132-ab8f-78399f1e978e}</UniqueIdentifier>
+      
+    
     </Filter>
+    
+  
   </ItemGroup>
+  
+  
   <ItemGroup>
+    
+    
     <ClCompile Include="dllmain.cpp">
+      
+      
       <Filter>Sources Files</Filter>
+      
+    
     </ClCompile>
+    
+    
     <ClCompile Include="imgui\imgui.cpp">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClCompile>
+    
+    
     <ClCompile Include="imgui\imgui_demo.cpp">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClCompile>
+    
+    
     <ClCompile Include="imgui\imgui_draw.cpp">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClCompile>
+    
+    
     <ClCompile Include="imgui\imgui_impl_dx12.cpp">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClCompile>
+    
+    
     <ClCompile Include="imgui\backends\imgui_impl_dx9.cpp">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClCompile>
+    
+    
     <ClCompile Include="imgui\imgui_impl_win32.cpp">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClCompile>
+    
+    
     <ClCompile Include="imgui\backends\imgui_impl_dx10.cpp">
+      
+      
+      <Filter>Sources Files\imgui</Filter>
+      
+    
+    </ClCompile>
+    
+    
+    <ClCompile Include="imgui\backends\imgui_impl_dx11.cpp">
       <Filter>Sources Files\imgui</Filter>
     </ClCompile>
     <ClCompile Include="imgui\imgui_tables.cpp">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClCompile>
+    
+    
     <ClCompile Include="imgui\imgui_widgets.cpp">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClCompile>
+    
+    
     <ClCompile Include="inputhooks.cpp">
+      
+      
       <Filter>Sources Files</Filter>
+      
+    
     </ClCompile>
+    
+    
     <ClCompile Include="hooks.cpp">
+      
+      
       <Filter>Sources Files</Filter>
+      
+    
     </ClCompile>
+    
+    
     <ClCompile Include="d3d12hook.cpp">
+      
+      
       <Filter>Sources Files</Filter>
+      
+    
     </ClCompile>
+    
+    
     <ClCompile Include="d3d10hook.cpp">
+      
+      
+      <Filter>Sources Files</Filter>
+      
+    
+    </ClCompile>
+    
+    
+    <ClCompile Include="d3d11hook.cpp">
       <Filter>Sources Files</Filter>
     </ClCompile>
     <ClCompile Include="d3d9hook.cpp">
+      
+      
       <Filter>Sources Files</Filter>
+      
+    
     </ClCompile>
+    
+    
     <ClCompile Include="menu.cpp">
+      
+      
       <Filter>Sources Files</Filter>
+      
+    
     </ClCompile>
+    
+    
     <ClCompile Include="globals.cpp">
+      
+      
       <Filter>Sources Files</Filter>
+      
+    
     </ClCompile>
+    
+  
   </ItemGroup>
+  
+  
   <ItemGroup>
+    
+    
     <ClInclude Include="imgui\imconfig.h">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClInclude>
+    
+    
     <ClInclude Include="imgui\imgui.h">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClInclude>
+    
+    
     <ClInclude Include="imgui\imgui_impl_dx12.h">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClInclude>
+    
+    
     <ClInclude Include="imgui\backends\imgui_impl_dx9.h">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClInclude>
+    
+    
     <ClInclude Include="imgui\imgui_impl_win32.h">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClInclude>
+    
+    
     <ClInclude Include="imgui\backends\imgui_impl_dx10.h">
+      
+      
+      <Filter>Sources Files\imgui</Filter>
+      
+    
+    </ClInclude>
+    
+    
+    <ClInclude Include="imgui\backends\imgui_impl_dx11.h">
       <Filter>Sources Files\imgui</Filter>
     </ClInclude>
     <ClInclude Include="imgui\imgui_internal.h">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClInclude>
+    
+    
     <ClInclude Include="imgui\imstb_rectpack.h">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClInclude>
+    
+    
     <ClInclude Include="imgui\imstb_textedit.h">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClInclude>
+    
+    
     <ClInclude Include="imgui\imstb_truetype.h">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </ClInclude>
+    
+    
     <ClInclude Include="d3d9hook.h">
+      
+      
+      <Filter>Sources Files</Filter>
+      
+    
+    </ClInclude>
+    
+    
+    <ClInclude Include="d3d11hook.h">
       <Filter>Sources Files</Filter>
     </ClInclude>
     <ClInclude Include="d3d10hook.h">
+      
+      
       <Filter>Sources Files</Filter>
+      
+    
     </ClInclude>
+    
+    
     <ClInclude Include="stdafx.h">
+      
+      
       <Filter>Sources Files</Filter>
+      
+    
     </ClInclude>
+    
+    
     <ClInclude Include="namespaces.h">
+      
+      
       <Filter>Sources Files</Filter>
+      
+    
     </ClInclude>
+    
+  
   </ItemGroup>
+  
+  
   <ItemGroup>
+    
+    
     <None Include="imgui\.editorconfig">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </None>
+    
+    
     <None Include="imgui\.gitattributes">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </None>
+    
+    
     <None Include="imgui\.gitignore">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </None>
+    
+  
   </ItemGroup>
+  
+  
   <ItemGroup>
+    
+    
     <Text Include="imgui\LICENSE.txt">
+      
+      
       <Filter>Sources Files\imgui</Filter>
+      
+    
     </Text>
+    
+  
   </ItemGroup>
+  
+
 </Project>

--- a/d3d11hook.cpp
+++ b/d3d11hook.cpp
@@ -1,0 +1,194 @@
+#include "stdafx.h"
+#include <d3d11.h>
+#include "imgui/backends/imgui_impl_dx11.h"
+#include "d3d11hook.h"
+
+#pragma comment(lib, "d3d11.lib")
+
+namespace hooks_dx11 {
+    using Microsoft::WRL::ComPtr;
+
+    PresentFn       oPresentD3D11 = nullptr;
+    ResizeBuffersFn oResizeBuffersD3D11 = nullptr;
+
+    static ID3D11Device*            gDevice = nullptr;
+    static ID3D11DeviceContext*     gContext = nullptr;
+    static IDXGISwapChain*          gSwapChain = nullptr;
+    static ID3D11RenderTargetView*  gRTV = nullptr;
+    static bool                     gInitialized = false;
+
+    static void CreateRenderTarget()
+    {
+        ID3D11Texture2D* pBackBuffer = nullptr;
+        if (gSwapChain && SUCCEEDED(gSwapChain->GetBuffer(0, IID_PPV_ARGS(&pBackBuffer))))
+        {
+            gDevice->CreateRenderTargetView(pBackBuffer, nullptr, &gRTV);
+            pBackBuffer->Release();
+        }
+    }
+
+    static void CleanupRenderTarget()
+    {
+        if (gRTV)
+        {
+            gRTV->Release();
+            gRTV = nullptr;
+        }
+    }
+
+    HRESULT __stdcall hookPresentD3D11(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags)
+    {
+        if (!gInitialized)
+        {
+            gSwapChain = pSwapChain;
+            if (SUCCEEDED(pSwapChain->GetDevice(__uuidof(ID3D11Device), (void**)&gDevice)))
+            {
+                gDevice->GetImmediateContext(&gContext);
+
+                DXGI_SWAP_CHAIN_DESC desc{};
+                pSwapChain->GetDesc(&desc);
+
+                ImGui::CreateContext();
+                ImGuiIO& io = ImGui::GetIO(); (void)io;
+                io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+                ImGui::StyleColorsDark();
+                ImGui_ImplWin32_Init(desc.OutputWindow);
+                ImGui_ImplDX11_Init(gDevice, gContext);
+                inputhook::Init(desc.OutputWindow);
+                CreateRenderTarget();
+                gInitialized = true;
+                DebugLog("[d3d11hook] ImGui initialized.\n");
+            }
+        }
+
+        if (GetAsyncKeyState(globals::openMenuKey) & 1)
+        {
+            menu::isOpen = !menu::isOpen;
+            DebugLog("[d3d11hook] Toggle menu: %d\n", menu::isOpen);
+        }
+
+        if (gInitialized)
+        {
+            ImGui_ImplDX11_NewFrame();
+            ImGui_ImplWin32_NewFrame();
+            ImGui::NewFrame();
+            if (menu::isOpen)
+                menu::Init();
+            ImGui::EndFrame();
+            ImGui::Render();
+            gContext->OMSetRenderTargets(1, &gRTV, nullptr);
+            ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
+        }
+
+        return oPresentD3D11(pSwapChain, SyncInterval, Flags);
+    }
+
+    HRESULT __stdcall hookResizeBuffersD3D11(
+        IDXGISwapChain* pSwapChain,
+        UINT BufferCount,
+        UINT Width,
+        UINT Height,
+        DXGI_FORMAT NewFormat,
+        UINT SwapChainFlags)
+    {
+        if (gInitialized)
+        {
+            ImGui_ImplDX11_InvalidateDeviceObjects();
+            CleanupRenderTarget();
+        }
+
+        HRESULT hr = oResizeBuffersD3D11(pSwapChain, BufferCount, Width, Height, NewFormat, SwapChainFlags);
+
+        if (gInitialized)
+        {
+            CreateRenderTarget();
+            ImGui_ImplDX11_CreateDeviceObjects();
+        }
+
+        return hr;
+    }
+
+    void Init()
+    {
+        DebugLog("[d3d11hook] Init starting\n");
+
+        WNDCLASSEXW wc = {
+            sizeof(WNDCLASSEXW), CS_CLASSDC, DefWindowProcW,
+            0L, 0L, GetModuleHandleW(nullptr), nullptr, nullptr, nullptr, nullptr,
+            L"DummyDX11", nullptr
+        };
+        RegisterClassExW(&wc);
+        HWND hwnd = CreateWindowW(wc.lpszClassName, L"", WS_OVERLAPPEDWINDOW,
+            0, 0, 100, 100, nullptr, nullptr, wc.hInstance, nullptr);
+
+        DXGI_SWAP_CHAIN_DESC sd{};
+        sd.BufferCount = 2;
+        sd.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        sd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        sd.OutputWindow = hwnd;
+        sd.SampleDesc.Count = 1;
+        sd.Windowed = TRUE;
+        sd.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
+
+        D3D_FEATURE_LEVEL featureLevel = D3D_FEATURE_LEVEL_11_0;
+        ID3D11Device* device = nullptr;
+        ID3D11DeviceContext* context = nullptr;
+        IDXGISwapChain* swapChain = nullptr;
+
+        HRESULT hr = D3D11CreateDeviceAndSwapChain(
+            nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, 0, &featureLevel, 1,
+            D3D11_SDK_VERSION, &sd, &swapChain, &device, nullptr, &context);
+
+        if (SUCCEEDED(hr))
+        {
+            void** vtbl = *reinterpret_cast<void***>(swapChain);
+            MH_CreateHook(vtbl[8], hookPresentD3D11, reinterpret_cast<void**>(&oPresentD3D11));
+            MH_CreateHook(vtbl[13], hookResizeBuffersD3D11, reinterpret_cast<void**>(&oResizeBuffersD3D11));
+            MH_EnableHook(vtbl[8]);
+            MH_EnableHook(vtbl[13]);
+            DebugLog("[d3d11hook] Hooks placed Present@%p ResizeBuffers@%p\n", vtbl[8], vtbl[13]);
+            swapChain->Release();
+            device->Release();
+            context->Release();
+        }
+        else
+        {
+            DebugLog("[d3d11hook] D3D11CreateDeviceAndSwapChain failed: 0x%08X\n", hr);
+        }
+
+        DestroyWindow(hwnd);
+        UnregisterClassW(wc.lpszClassName, wc.hInstance);
+    }
+
+    void release()
+    {
+        DebugLog("[d3d11hook] Releasing resources\n");
+
+        if (globals::mainWindow)
+            inputhook::Remove(globals::mainWindow);
+
+        if (gInitialized)
+        {
+            ImGui_ImplDX11_Shutdown();
+            ImGui_ImplWin32_Shutdown();
+            ImGui::DestroyContext();
+            CleanupRenderTarget();
+            if (gContext)
+            {
+                gContext->Release();
+                gContext = nullptr;
+            }
+            if (gDevice)
+            {
+                gDevice->Release();
+                gDevice = nullptr;
+            }
+            gSwapChain = nullptr;
+            gInitialized = false;
+        }
+
+        MH_DisableHook(MH_ALL_HOOKS);
+        MH_RemoveHook(MH_ALL_HOOKS);
+        MH_Uninitialize();
+    }
+}

--- a/d3d11hook.h
+++ b/d3d11hook.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <d3d11.h>
+#include <dxgi.h>
+
+namespace hooks_dx11 {
+    using PresentFn = HRESULT(__stdcall*)(IDXGISwapChain*, UINT, UINT);
+    using ResizeBuffersFn = HRESULT(__stdcall*)(IDXGISwapChain*, UINT, UINT, UINT, DXGI_FORMAT, UINT);
+
+    extern PresentFn       oPresentD3D11;
+    extern ResizeBuffersFn oResizeBuffersD3D11;
+
+    HRESULT __stdcall hookPresentD3D11(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags);
+    HRESULT __stdcall hookResizeBuffersD3D11(
+        IDXGISwapChain* pSwapChain,
+        UINT BufferCount,
+        UINT Width,
+        UINT Height,
+        DXGI_FORMAT NewFormat,
+        UINT SwapChainFlags);
+
+    void Init();
+    void release();
+}


### PR DESCRIPTION
## Summary
- Implement d3d11 swapchain hooks capturing Present and ResizeBuffers
- Bootstrap a dummy DX11 device to locate vtable slots and initialize ImGui with DX11 backend
- Wire DX11 sources and headers into the project

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -c d3d11hook.cpp -I. -Iimgui -ID:/fake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b9943de083248225f2e678901c5d