### PR TITLE
Add Vulkan hook with ImGui initialization

### DIFF
--- a/vulkanhook.h
+++ b/vulkanhook.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+
+namespace hooks_vk {
+    extern PFN_vkCreateInstance        oCreateInstance;
+    extern PFN_vkCreateDevice          oCreateDevice;
+    extern PFN_vkQueuePresentKHR       oQueuePresentKHR;
+
+    VkResult VKAPI_PTR hook_vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
+                                             const VkAllocationCallbacks* pAllocator,
+                                             VkInstance* pInstance);
+    VkResult VKAPI_PTR hook_vkCreateDevice(VkPhysicalDevice physicalDevice,
+                                           const VkDeviceCreateInfo* pCreateInfo,
+                                           const VkAllocationCallbacks* pAllocator,
+                                           VkDevice* pDevice);
+    VkResult VKAPI_PTR hook_vkQueuePresentKHR(VkQueue queue,
+                                              const VkPresentInfoKHR* pPresentInfo);
+
+    void Init();
+    void release();
+}
+


### PR DESCRIPTION
## Summary
- hook vkCreateInstance, vkCreateDevice, and vkQueuePresentKHR via function pointers
- initialize ImGui with Vulkan backend, managing descriptor pool and per-frame command buffers
- add cleanup logic for Vulkan resources when detaching

## Testing
- `msbuild Universal-ImGui-Hook.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bbfedfc48324bc0114796e83e47e