### PR TITLE
Support Present1 hook for DX11/DX12 swap chains

### DIFF
--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -2,6 +2,7 @@
 
 namespace d3d12hook {
     PresentD3D12            oPresentD3D12 = nullptr;
+    Present1Fn              oPresent1D3D12 = nullptr;
     ExecuteCommandListsFn   oExecuteCommandListsD3D12 = nullptr;
     SignalFn                oSignalD3D12 = nullptr;
     ResizeBuffersFn         oResizeBuffersD3D12 = nullptr;
@@ -205,6 +206,183 @@ namespace d3d12hook {
         }
 
         return oPresentD3D12(pSwapChain, SyncInterval, Flags);
+    }
+
+    long __fastcall hookPresent1D3D12(IDXGISwapChain3* pSwapChain, UINT SyncInterval, UINT Flags, const DXGI_PRESENT_PARAMETERS* pParams) {
+        if (GetAsyncKeyState(globals::openMenuKey) & 1) {
+            menu::isOpen = !menu::isOpen;
+            DebugLog("[d3d12hook] Toggle menu: isOpen=%d\n", menu::isOpen);
+        }
+
+        if (!gInitialized) {
+            DebugLog("[d3d12hook] Initializing ImGui on first Present1.\n");
+            if (FAILED(pSwapChain->GetDevice(__uuidof(ID3D12Device), (void**)&gDevice))) {
+                LogHRESULT("GetDevice", E_FAIL);
+                return oPresent1D3D12(pSwapChain, SyncInterval, Flags, pParams);
+            }
+
+            // Swap Chain description
+            DXGI_SWAP_CHAIN_DESC desc = {};
+            pSwapChain->GetDesc(&desc);
+            gBufferCount = desc.BufferCount;
+            DebugLog("[d3d12hook] BufferCount=%u\n", gBufferCount);
+
+            // Create descriptor heaps
+            D3D12_DESCRIPTOR_HEAP_DESC heapDesc = {};
+            heapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+            heapDesc.NumDescriptors = gBufferCount;
+            if (FAILED(gDevice->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(&gHeapRTV)))) {
+                LogHRESULT("CreateDescriptorHeap RTV", E_FAIL);
+                return oPresent1D3D12(pSwapChain, SyncInterval, Flags, pParams);
+            }
+
+            heapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+            heapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+            if (FAILED(gDevice->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(&gHeapSRV)))) {
+                LogHRESULT("CreateDescriptorHeap SRV", E_FAIL);
+                return oPresent1D3D12(pSwapChain, SyncInterval, Flags, pParams);
+            }
+
+            // Allocate frame contexts
+            gFrameContexts = new FrameContext[gBufferCount];
+            ZeroMemory(gFrameContexts, sizeof(FrameContext) * gBufferCount);
+
+            // Create command allocator for each frame
+            for (UINT i = 0; i < gBufferCount; ++i) {
+                if (FAILED(gDevice->CreateCommandAllocator(
+                        D3D12_COMMAND_LIST_TYPE_DIRECT,
+                        IID_PPV_ARGS(&gFrameContexts[i].allocator)))) {
+                    LogHRESULT("CreateCommandAllocator", E_FAIL);
+                    return oPresent1D3D12(pSwapChain, SyncInterval, Flags, pParams);
+                }
+            }
+
+            // Create RTVs for each back buffer
+            UINT rtvSize = gDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+            auto rtvHandle = gHeapRTV->GetCPUDescriptorHandleForHeapStart();
+            for (UINT i = 0; i < gBufferCount; ++i) {
+                ID3D12Resource* back;
+                pSwapChain->GetBuffer(i, IID_PPV_ARGS(&back));
+                gDevice->CreateRenderTargetView(back, nullptr, rtvHandle);
+                gFrameContexts[i].renderTarget = back;
+                gFrameContexts[i].rtvHandle = rtvHandle;
+                rtvHandle.ptr += rtvSize;
+            }
+
+            // ImGui setup
+            ImGui::CreateContext();
+            ImGuiIO& io = ImGui::GetIO(); (void)io;
+            io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+            ImGui::StyleColorsDark();
+            ImGui_ImplWin32_Init(desc.OutputWindow);
+            ImGui_ImplDX12_Init(gDevice, gBufferCount,
+                desc.BufferDesc.Format,
+                gHeapSRV,
+                gHeapSRV->GetCPUDescriptorHandleForHeapStart(),
+                gHeapSRV->GetGPUDescriptorHandleForHeapStart());
+            DebugLog("[d3d12hook] ImGui initialized.\n");
+
+            inputhook::Init(desc.OutputWindow);
+
+            if (!gFenceEvent) {
+                gFenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+                if (!gFenceEvent) {
+                    DebugLog("[d3d12hook] Failed to create fence event: %lu\n", GetLastError());
+                }
+            }
+
+            // Hook CommandQueue and Fence are already captured by minhook
+            gInitialized = true;
+        }
+
+        if (!gShutdown) {
+            // Render ImGui
+            ImGui_ImplDX12_NewFrame();
+            ImGui_ImplWin32_NewFrame();
+            ImGui::NewFrame();
+
+            if (menu::isOpen) menu::Init();
+
+            UINT frameIdx = pSwapChain->GetCurrentBackBufferIndex();
+            FrameContext& ctx = gFrameContexts[frameIdx];
+
+            // Wait for the GPU to finish with the previous frame
+            if (!gFence || !gFenceEvent) {
+                // Missing synchronization objects, skip waiting
+            } else if (gFence->GetCompletedValue() < gFenceValue) {
+                HRESULT hr = gFence->SetEventOnCompletion(gFenceValue, gFenceEvent);
+                if (SUCCEEDED(hr)) {
+                    const DWORD waitTimeoutMs = 1000; // 1 second timeout
+                    DWORD waitRes = WaitForSingleObject(gFenceEvent, waitTimeoutMs);
+                    if (waitRes == WAIT_TIMEOUT) {
+                        DebugLog("[d3d12hook] WaitForSingleObject timeout\n");
+                    } else if (waitRes != WAIT_OBJECT_0) {
+                        DebugLog("[d3d12hook] WaitForSingleObject failed: %lu\n", GetLastError());
+                    }
+                } else {
+                    LogHRESULT("SetEventOnCompletion", hr);
+                }
+            }
+
+            // Reset allocator and command list using frame-specific allocator
+            HRESULT hr = ctx.allocator->Reset();
+            if (FAILED(hr)) {
+                LogHRESULT("CommandAllocator->Reset", hr);
+                return oPresent1D3D12(pSwapChain, SyncInterval, Flags, pParams);
+            }
+
+            if (!gCommandList) {
+                hr = gDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT,
+                    ctx.allocator, nullptr, IID_PPV_ARGS(&gCommandList));
+                if (FAILED(hr)) {
+                    LogHRESULT("CreateCommandList", hr);
+                    return oPresent1D3D12(pSwapChain, SyncInterval, Flags, pParams);
+                }
+                gCommandList->Close();
+            }
+            hr = gCommandList->Reset(ctx.allocator, nullptr);
+            if (FAILED(hr)) {
+                LogHRESULT("CommandList->Reset", hr);
+                return oPresent1D3D12(pSwapChain, SyncInterval, Flags, pParams);
+            }
+
+            // Transition to render target
+            D3D12_RESOURCE_BARRIER barrier = {};
+            barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+            barrier.Transition.pResource = ctx.renderTarget;
+            barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_PRESENT;
+            barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
+            gCommandList->ResourceBarrier(1, &barrier);
+
+            gCommandList->OMSetRenderTargets(1, &ctx.rtvHandle, FALSE, nullptr);
+            ID3D12DescriptorHeap* heaps[] = { gHeapSRV };
+            gCommandList->SetDescriptorHeaps(1, heaps);
+
+            ImGui::Render();
+            ImGui_ImplDX12_RenderDrawData(ImGui::GetDrawData(), gCommandList);
+
+            // Transition back to present
+            barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
+            barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
+            gCommandList->ResourceBarrier(1, &barrier);
+            gCommandList->Close();
+
+            // Execute
+            if (!gCommandQueue) {
+                DebugLog("[d3d12hook] CommandQueue not set, skipping ExecuteCommandLists.\n");
+            }
+            else {
+                oExecuteCommandListsD3D12(gCommandQueue, 1, reinterpret_cast<ID3D12CommandList* const*>(&gCommandList));
+                if (gFence) {
+                    HRESULT hr = gCommandQueue->Signal(gFence, ++gFenceValue);
+                    if (FAILED(hr)) {
+                        LogHRESULT("Signal", hr);
+                    }
+                }
+            }
+        }
+
+        return oPresent1D3D12(pSwapChain, SyncInterval, Flags, pParams);
     }
 
     void STDMETHODCALLTYPE hookExecuteCommandListsD3D12(

--- a/namespaces.h
+++ b/namespaces.h
@@ -29,9 +29,12 @@ namespace inputhook {
 }
 
 namespace d3d12hook {
-	typedef HRESULT(STDMETHODCALLTYPE* PresentD3D12)(
-		IDXGISwapChain3 * pSwapChain, UINT SyncInterval, UINT Flags);
-	extern PresentD3D12 oPresentD3D12;
+        typedef HRESULT(STDMETHODCALLTYPE* PresentD3D12)(
+                IDXGISwapChain3 * pSwapChain, UINT SyncInterval, UINT Flags);
+        typedef HRESULT(STDMETHODCALLTYPE* Present1Fn)(
+                IDXGISwapChain3 * pSwapChain, UINT SyncInterval, UINT Flags, const DXGI_PRESENT_PARAMETERS* pParams);
+        extern PresentD3D12 oPresentD3D12;
+        extern Present1Fn   oPresent1D3D12;
 
 	typedef void(STDMETHODCALLTYPE* ExecuteCommandListsFn)(
 		ID3D12CommandQueue * _this, UINT NumCommandLists, ID3D12CommandList* const* ppCommandLists);
@@ -58,7 +61,8 @@ namespace d3d12hook {
                 DXGI_FORMAT NewFormat,
                 UINT SwapChainFlags);
 
-	extern long __fastcall hookPresentD3D12(IDXGISwapChain3* pSwapChain, UINT SyncInterval, UINT Flags);
+        extern long __fastcall hookPresentD3D12(IDXGISwapChain3* pSwapChain, UINT SyncInterval, UINT Flags);
+        extern long __fastcall hookPresent1D3D12(IDXGISwapChain3* pSwapChain, UINT SyncInterval, UINT Flags, const DXGI_PRESENT_PARAMETERS* pParams);
 	extern void STDMETHODCALLTYPE hookExecuteCommandListsD3D12(
 		ID3D12CommandQueue* _this,
 		UINT                          NumCommandLists,
@@ -108,13 +112,16 @@ namespace hooks_dx10 {
 }
 
 namespace hooks_dx11 {
-    using PresentFn = HRESULT(__stdcall*)(IDXGISwapChain*, UINT, UINT);
+    using PresentFn   = HRESULT(__stdcall*)(IDXGISwapChain*, UINT, UINT);
+    using Present1Fn  = HRESULT(__stdcall*)(IDXGISwapChain1*, UINT, UINT, const DXGI_PRESENT_PARAMETERS*);
     using ResizeBuffersFn = HRESULT(__stdcall*)(IDXGISwapChain*, UINT, UINT, UINT, DXGI_FORMAT, UINT);
 
     extern PresentFn       oPresentD3D11;
+    extern Present1Fn      oPresent1D3D11;
     extern ResizeBuffersFn oResizeBuffersD3D11;
 
     HRESULT __stdcall hookPresentD3D11(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags);
+    HRESULT __stdcall hookPresent1D3D11(IDXGISwapChain1* pSwapChain, UINT SyncInterval, UINT Flags, const DXGI_PRESENT_PARAMETERS* pPresentParameters);
     HRESULT __stdcall hookResizeBuffersD3D11(
         IDXGISwapChain* pSwapChain,
         UINT BufferCount,


### PR DESCRIPTION
## Summary
- declare Present1 function types and global hooks for DX11 and DX12
- add new Present1 hook implementations and install them during init
- log Present1 hook addresses for easier debugging

## Testing
- `x86_64-w64-mingw32-g++ --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d01c87088324a94006776663ce8b