### PR TITLE
Prioritize DX12 detection

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -16,25 +16,25 @@ static void InitForModule(const char* name)
     const char* base = strrchr(name, '\\');
     base = base ? base + 1 : name;
 
-    if (_stricmp(base, "d3d9.dll") == 0) {
-        DebugLog("[DllMain] LoadLibrary detected d3d9.dll, initializing DX9 hooks.\n");
-        d3d9hook::Init();
-        globals::activeBackend = globals::Backend::DX9;
-    }
-    else if (_stricmp(base, "d3d10.dll") == 0) {
-        DebugLog("[DllMain] LoadLibrary detected d3d10.dll, initializing DX10 hooks.\n");
-        hooks_dx10::Init();
-        globals::activeBackend = globals::Backend::DX10;
+    if (_stricmp(base, "d3d12.dll") == 0 || _stricmp(base, "dxgi.dll") == 0) {
+        DebugLog("[DllMain] LoadLibrary detected DX12/dxgi module, initializing DX12 hooks.\n");
+        hooks::Init();
+        globals::activeBackend = globals::Backend::DX12;
     }
     else if (_stricmp(base, "d3d11.dll") == 0) {
         DebugLog("[DllMain] LoadLibrary detected d3d11.dll, initializing DX11 hooks.\n");
         hooks_dx11::Init();
         globals::activeBackend = globals::Backend::DX11;
     }
-    else if (_stricmp(base, "d3d12.dll") == 0 || _stricmp(base, "dxgi.dll") == 0) {
-        DebugLog("[DllMain] LoadLibrary detected DX12/dxgi module, initializing DX12 hooks.\n");
-        hooks::Init();
-        globals::activeBackend = globals::Backend::DX12;
+    else if (_stricmp(base, "d3d10.dll") == 0) {
+        DebugLog("[DllMain] LoadLibrary detected d3d10.dll, initializing DX10 hooks.\n");
+        hooks_dx10::Init();
+        globals::activeBackend = globals::Backend::DX10;
+    }
+    else if (_stricmp(base, "d3d9.dll") == 0) {
+        DebugLog("[DllMain] LoadLibrary detected d3d9.dll, initializing DX9 hooks.\n");
+        d3d9hook::Init();
+        globals::activeBackend = globals::Backend::DX9;
     }
     else if (_stricmp(base, "vulkan-1.dll") == 0) {
         DebugLog("[DllMain] LoadLibrary detected vulkan-1.dll, initializing Vulkan hooks.\n");
@@ -83,25 +83,25 @@ static DWORD WINAPI onAttach(LPVOID lpParameter)
 
     // Detect loaded rendering backends and initialize hooks accordingly
     HMODULE mod = nullptr;
-    if ((mod = GetModuleHandleA("d3d9.dll"))) {
-        DebugLog("[DllMain] Detected d3d9.dll (%p). Initializing DX9 hooks.\n", mod);
-        d3d9hook::Init();
-        globals::activeBackend = globals::Backend::DX9;
-    }
-    else if ((mod = GetModuleHandleA("d3d10.dll"))) {
-        DebugLog("[DllMain] Detected d3d10.dll (%p). Initializing DX10 hooks.\n", mod);
-        hooks_dx10::Init();
-        globals::activeBackend = globals::Backend::DX10;
+    if ((mod = GetModuleHandleA("d3d12.dll")) || (mod = GetModuleHandleA("dxgi.dll"))) {
+        DebugLog("[DllMain] Detected DX12/dxgi module (%p). Initializing DX12 hooks.\n", mod);
+        hooks::Init();
+        globals::activeBackend = globals::Backend::DX12;
     }
     else if ((mod = GetModuleHandleA("d3d11.dll"))) {
         DebugLog("[DllMain] Detected d3d11.dll (%p). Initializing DX11 hooks.\n", mod);
         hooks_dx11::Init();
         globals::activeBackend = globals::Backend::DX11;
     }
-    else if ((mod = GetModuleHandleA("d3d12.dll")) || (mod = GetModuleHandleA("dxgi.dll"))) {
-        DebugLog("[DllMain] Detected DX12/dxgi module (%p). Initializing DX12 hooks.\n", mod);
-        hooks::Init();
-        globals::activeBackend = globals::Backend::DX12;
+    else if ((mod = GetModuleHandleA("d3d10.dll"))) {
+        DebugLog("[DllMain] Detected d3d10.dll (%p). Initializing DX10 hooks.\n", mod);
+        hooks_dx10::Init();
+        globals::activeBackend = globals::Backend::DX10;
+    }
+    else if ((mod = GetModuleHandleA("d3d9.dll"))) {
+        DebugLog("[DllMain] Detected d3d9.dll (%p). Initializing DX9 hooks.\n", mod);
+        d3d9hook::Init();
+        globals::activeBackend = globals::Backend::DX9;
     }
     else if ((mod = GetModuleHandleA("vulkan-1.dll"))) {
         DebugLog("[DllMain] Detected vulkan-1.dll (%p). Initializing Vulkan hooks.\n", mod);


### PR DESCRIPTION
## Summary
- detect d3d12/dxgi before older DirectX modules
- initialize hooks with the highest detected backend and set `globals::activeBackend`

## Testing
- `g++ -fsyntax-only dllmain.cpp` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d47540848324bff3f518aafa8b7d