### PR TITLE
Add runtime uninject support across rendering hooks

### DIFF
--- a/d3d10hook.cpp
+++ b/d3d10hook.cpp
@@ -60,6 +60,12 @@ namespace hooks_dx10 {
             DebugLog("[d3d10hook] Toggle menu: %d\n", menu::isOpen);
         }
 
+        if (GetAsyncKeyState(globals::uninjectKey) & 1)
+        {
+            Uninject();
+            return;
+        }
+
         if (gInitialized)
         {
             ImGui_ImplDX10_NewFrame();

--- a/d3d11hook.cpp
+++ b/d3d11hook.cpp
@@ -63,6 +63,12 @@ namespace hooks_dx11 {
             DebugLog("[d3d11hook] Toggle menu: %d\n", menu::isOpen);
         }
 
+        if (GetAsyncKeyState(globals::uninjectKey) & 1)
+        {
+            Uninject();
+            return;
+        }
+
         if (gInitialized)
         {
             ImGui_ImplDX11_NewFrame();

--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -37,6 +37,11 @@ namespace d3d12hook {
             DebugLog("[d3d12hook] Toggle menu: isOpen=%d\n", menu::isOpen);
         }
 
+        if (GetAsyncKeyState(globals::uninjectKey) & 1) {
+            Uninject();
+            return oPresentD3D12(pSwapChain, SyncInterval, Flags);
+        }
+
         if (!gInitialized) {
             DebugLog("[d3d12hook] Initializing ImGui on first Present.\n");
             if (FAILED(pSwapChain->GetDevice(__uuidof(ID3D12Device), (void**)&gDevice))) {
@@ -212,6 +217,11 @@ namespace d3d12hook {
         if (GetAsyncKeyState(globals::openMenuKey) & 1) {
             menu::isOpen = !menu::isOpen;
             DebugLog("[d3d12hook] Toggle menu: isOpen=%d\n", menu::isOpen);
+        }
+
+        if (GetAsyncKeyState(globals::uninjectKey) & 1) {
+            Uninject();
+            return oPresent1D3D12(pSwapChain, SyncInterval, Flags, pParams);
         }
 
         if (!gInitialized) {

--- a/d3d9hook.cpp
+++ b/d3d9hook.cpp
@@ -27,6 +27,11 @@ namespace d3d9hook {
             DebugLog("[d3d9hook] Toggle menu: %d\\n", menu::isOpen);
         }
 
+        if (GetAsyncKeyState(globals::uninjectKey) & 1) {
+            Uninject();
+            return oEndScene(device);
+        }
+
         if (gInitialized) {
             ImGui_ImplDX9_NewFrame();
             ImGui_ImplWin32_NewFrame();

--- a/namespaces.h
+++ b/namespaces.h
@@ -157,6 +157,9 @@ namespace hooks_vk {
 }
 
 namespace menu {
-	extern bool isOpen;
-	extern void Init();
+        extern bool isOpen;
+        extern void Init();
 }
+
+// Helper to unload the DLL and remove all hooks
+void Uninject();

--- a/vulkanhook.cpp
+++ b/vulkanhook.cpp
@@ -300,6 +300,12 @@ namespace hooks_vk {
             DebugLog("[vulkanhook] Toggle menu: %d\n", menu::isOpen);
         }
 
+        if (GetAsyncKeyState(globals::uninjectKey) & 1)
+        {
+            Uninject();
+            return oQueuePresentKHR(queue, pPresentInfo);
+        }
+
         if (gInitialized && pPresentInfo && pPresentInfo->pImageIndices)
         {
             uint32_t image_index = pPresentInfo->pImageIndices[0];


### PR DESCRIPTION
## Summary
- add `Uninject` helper to release active backend hooks, uninitialize MinHook, and unload the DLL
- allow F12 (configurable) to trigger uninject in all frame hooks

## Testing
- `g++ -std=c++17 -c dllmain.cpp` *(fails: fatal error: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d8e3449083248f7d3535eddf651d