### PR TITLE
Add runtime toggle for debug logging

### DIFF
--- a/globals.cpp
+++ b/globals.cpp
@@ -11,6 +11,14 @@ namespace globals {
     int openMenuKey = VK_INSERT;
     // Currently active rendering backend
     Backend activeBackend = Backend::None;
+    // Flag controlling runtime debug logging
+    bool enableDebugLog = true;
+}
+
+namespace globals {
+    void SetDebugLogging(bool enable) {
+        enableDebugLog = enable;
+    }
 }
 
 // Log initial global values for debugging

--- a/namespaces.h
+++ b/namespaces.h
@@ -16,6 +16,8 @@ namespace globals {
                 Vulkan
         };
         extern Backend activeBackend;
+        extern bool enableDebugLog;
+        void SetDebugLogging(bool enable);
 }
 
 namespace hooks {

--- a/stdafx.h
+++ b/stdafx.h
@@ -47,6 +47,9 @@ typedef uint32_t uintx_t;
 
 // Helper macro for debug logging via DebugView
 inline void DebugLog(const char* fmt, ...) {
+    if (!globals::enableDebugLog) {
+        return;
+    }
     char buf[512];
     va_list args;
     va_start(args, fmt);


### PR DESCRIPTION
## Summary
- add `globals::enableDebugLog` flag and setter to control debug messages
- gate `DebugLog` behind `globals::enableDebugLog`

## Testing
- `g++ -std=c++17 -c globals.cpp` *(fails: windows.h missing)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e219019c8324bfe62a80791b6155