### PR TITLE
Add backend initialization checks with fallback

### DIFF
--- a/d3d10hook.cpp
+++ b/d3d10hook.cpp
@@ -203,4 +203,9 @@ namespace hooks_dx10 {
         MH_RemoveHook(MH_ALL_HOOKS);
         MH_Uninitialize();
     }
+
+    bool IsInitialized()
+    {
+        return gInitialized;
+    }
 }

--- a/d3d11hook.cpp
+++ b/d3d11hook.cpp
@@ -242,4 +242,9 @@ namespace hooks_dx11 {
         MH_RemoveHook(MH_ALL_HOOKS);
         MH_Uninitialize();
     }
+
+    bool IsInitialized()
+    {
+        return gInitialized;
+    }
 }

--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -540,4 +540,9 @@ namespace d3d12hook {
         MH_Uninitialize();
         DebugLog("[DllMain] MinHook uninitialized.\n");
     }
+
+    bool IsInitialized()
+    {
+        return gInitialized;
+    }
 }

--- a/d3d9hook.cpp
+++ b/d3d9hook.cpp
@@ -113,4 +113,9 @@ namespace d3d9hook {
         MH_RemoveHook(MH_ALL_HOOKS);
         MH_Uninitialize();
     }
+
+    bool IsInitialized()
+    {
+        return gInitialized;
+    }
 }

--- a/namespaces.h
+++ b/namespaces.h
@@ -70,12 +70,13 @@ namespace d3d12hook {
 		UINT                          NumCommandLists,
 		ID3D12CommandList* const* ppCommandLists);
 
-	extern HRESULT STDMETHODCALLTYPE hookSignalD3D12(
-		ID3D12CommandQueue* _this,
-		ID3D12Fence* pFence,
-		UINT64              Value);
+        extern HRESULT STDMETHODCALLTYPE hookSignalD3D12(
+                ID3D12CommandQueue* _this,
+                ID3D12Fence* pFence,
+                UINT64              Value);
 
         extern void release();
+        bool IsInitialized();
 }
 
 // Forward declarations for other rendering backends
@@ -91,6 +92,7 @@ namespace d3d9hook {
 
     void Init();
     void release();
+    bool IsInitialized();
 }
 
 namespace hooks_dx10 {
@@ -114,6 +116,7 @@ namespace hooks_dx10 {
 
     void Init();
     void release();
+    bool IsInitialized();
 }
 
 namespace hooks_dx11 {
@@ -137,6 +140,7 @@ namespace hooks_dx11 {
 
     void Init();
     void release();
+    bool IsInitialized();
 }
 
 namespace hooks_vk {
@@ -156,6 +160,7 @@ namespace hooks_vk {
 
     void Init();
     void release();
+    bool IsInitialized();
 }
 
 namespace menu {

--- a/vulkanhook.cpp
+++ b/vulkanhook.cpp
@@ -476,5 +476,10 @@ namespace hooks_vk {
         MH_RemoveHook(MH_ALL_HOOKS);
         MH_Uninitialize();
     }
+
+    bool IsInitialized()
+    {
+        return gInitialized;
+    }
 }
 


### PR DESCRIPTION
## Summary
- expose IsInitialized helper in every rendering backend
- add initialization wait and fallback chain with debug logging
- only set activeBackend after successful initialization

## Testing
- `g++ -std=c++17 -fsyntax-only dllmain.cpp` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e9fc23b48324969c1fd13d6ae677