### PR TITLE
Avoid MinHook deinit during backend fallback

### DIFF
--- a/d3d10hook.cpp
+++ b/d3d10hook.cpp
@@ -6,6 +6,9 @@ namespace hooks_dx10 {
     PresentFn       oPresentD3D10 = nullptr;
     Present1Fn      oPresent1D3D10 = nullptr;
     ResizeBuffersFn oResizeBuffersD3D10 = nullptr;
+    static void* pPresentTarget = nullptr;
+    static void* pPresent1Target = nullptr;
+    static void* pResizeBuffersTarget = nullptr;
 
     static ID3D10Device*           gDevice = nullptr;
     static IDXGISwapChain*         gSwapChain = nullptr;
@@ -148,8 +151,10 @@ namespace hooks_dx10 {
         if (SUCCEEDED(hr))
         {
             void** vtbl = *reinterpret_cast<void***>(swapChain);
-            MH_CreateHook(vtbl[8], hookPresentD3D10, reinterpret_cast<void**>(&oPresentD3D10));
-            MH_CreateHook(vtbl[13], hookResizeBuffersD3D10, reinterpret_cast<void**>(&oResizeBuffersD3D10));
+            pPresentTarget = vtbl[8];
+            pResizeBuffersTarget = vtbl[13];
+            MH_CreateHook(pPresentTarget, hookPresentD3D10, reinterpret_cast<void**>(&oPresentD3D10));
+            MH_CreateHook(pResizeBuffersTarget, hookResizeBuffersD3D10, reinterpret_cast<void**>(&oResizeBuffersD3D10));
 
             IDXGISwapChain1* swapChain1 = nullptr;
             void* present1Addr = nullptr;
@@ -157,14 +162,15 @@ namespace hooks_dx10 {
             {
                 void** vtbl1 = *reinterpret_cast<void***>(swapChain1);
                 present1Addr = vtbl1[22];
-                MH_CreateHook(vtbl1[22], hookPresent1D3D10, reinterpret_cast<void**>(&oPresent1D3D10));
-                MH_EnableHook(vtbl1[22]);
+                pPresent1Target = vtbl1[22];
+                MH_CreateHook(pPresent1Target, hookPresent1D3D10, reinterpret_cast<void**>(&oPresent1D3D10));
+                MH_EnableHook(pPresent1Target);
                 swapChain1->Release();
             }
 
-            MH_EnableHook(vtbl[8]);
-            MH_EnableHook(vtbl[13]);
-            DebugLog("[d3d10hook] Hooks placed Present@%p Present1@%p ResizeBuffers@%p\n", vtbl[8], present1Addr, vtbl[13]);
+            MH_EnableHook(pPresentTarget);
+            MH_EnableHook(pResizeBuffersTarget);
+            DebugLog("[d3d10hook] Hooks placed Present@%p Present1@%p ResizeBuffers@%p\n", pPresentTarget, present1Addr, pResizeBuffersTarget);
             swapChain->Release();
             device->Release();
         }
@@ -199,9 +205,21 @@ namespace hooks_dx10 {
             gInitialized = false;
         }
 
-        MH_DisableHook(MH_ALL_HOOKS);
-        MH_RemoveHook(MH_ALL_HOOKS);
-        MH_Uninitialize();
+        if (pPresentTarget) {
+            MH_DisableHook(pPresentTarget);
+            MH_RemoveHook(pPresentTarget);
+            pPresentTarget = nullptr;
+        }
+        if (pPresent1Target) {
+            MH_DisableHook(pPresent1Target);
+            MH_RemoveHook(pPresent1Target);
+            pPresent1Target = nullptr;
+        }
+        if (pResizeBuffersTarget) {
+            MH_DisableHook(pResizeBuffersTarget);
+            MH_RemoveHook(pResizeBuffersTarget);
+            pResizeBuffersTarget = nullptr;
+        }
     }
 
     bool IsInitialized()

--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -1,5 +1,7 @@
 #include "stdafx.h"
 
+namespace hooks { void Remove(); }
+
 namespace d3d12hook {
     PresentD3D12            oPresentD3D12 = nullptr;
     Present1Fn              oPresent1D3D12 = nullptr;
@@ -523,22 +525,8 @@ namespace d3d12hook {
         if (gDevice) gDevice->Release();
         delete[] gFrameContexts;
 
-        // Unhook
-        MH_STATUS mh = MH_DisableHook(MH_ALL_HOOKS);
-        if (mh != MH_OK)
-            DebugLog("[d3d12hook] MH_DisableHook failed: %s\n", MH_StatusToString(mh));
-        else
-            DebugLog("[d3d12hook] Hooks disabled.\n");
-
-        mh = MH_RemoveHook(MH_ALL_HOOKS);
-        if (mh != MH_OK)
-            DebugLog("[d3d12hook] MH_RemoveHook failed: %s\n", MH_StatusToString(mh));
-        else
-            DebugLog("[d3d12hook] Hooks removed.\n");
-
-        // Uninitialize MinHook
-        MH_Uninitialize();
-        DebugLog("[DllMain] MinHook uninitialized.\n");
+        // Disable hooks installed for D3D12
+        hooks::Remove();
     }
 
     bool IsInitialized()

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -237,7 +237,9 @@ static DWORD WINAPI UninjectThread(LPVOID)
         break;
     }
 
-    // Ensure MinHook is uninitialized (release() may already do this)
+    // Disable and remove all hooks, then uninitialize MinHook
+    MH_DisableHook(MH_ALL_HOOKS);
+    MH_RemoveHook(MH_ALL_HOOKS);
     MH_Uninitialize();
 
     DebugLog("[DllMain] Unloading module and exiting thread.\n");
@@ -334,6 +336,9 @@ BOOL WINAPI DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved
         default:
             break;
         }
+        MH_DisableHook(MH_ALL_HOOKS);
+        MH_RemoveHook(MH_ALL_HOOKS);
+        MH_Uninitialize();
         break;
     }
     return TRUE;

--- a/vulkanhook.cpp
+++ b/vulkanhook.cpp
@@ -472,9 +472,21 @@ namespace hooks_vk {
         gDevice = VK_NULL_HANDLE;
         gInstance = VK_NULL_HANDLE;
 
-        MH_DisableHook(MH_ALL_HOOKS);
-        MH_RemoveHook(MH_ALL_HOOKS);
-        MH_Uninitialize();
+        if (oQueuePresentKHR) {
+            MH_DisableHook((void*)oQueuePresentKHR);
+            MH_RemoveHook((void*)oQueuePresentKHR);
+            oQueuePresentKHR = nullptr;
+        }
+        if (oCreateInstance) {
+            MH_DisableHook((void*)oCreateInstance);
+            MH_RemoveHook((void*)oCreateInstance);
+            oCreateInstance = nullptr;
+        }
+        if (oCreateDevice) {
+            MH_DisableHook((void*)oCreateDevice);
+            MH_RemoveHook((void*)oCreateDevice);
+            oCreateDevice = nullptr;
+        }
     }
 
     bool IsInitialized()


### PR DESCRIPTION
## Summary
- keep MinHook active when a backend release is triggered by a failed init
- track and remove hooks per backend instead of tearing down all MinHook hooks
- uninitialize MinHook only during final DLL detach or manual uninject

## Testing
- `g++ -c d3d9hook.cpp` *(fails: windows.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68a5ec4df33c8324bcdbab7d9cecdd61