### PR TITLE
Add global preferred backend selection

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -172,6 +172,9 @@ static void InitForModule(const char* name)
         return;
     }
 
+    if (globals::preferredBackend != globals::Backend::None && detected != globals::preferredBackend)
+        return;
+
     if (GetBackendPriority(detected) <= GetBackendPriority(globals::activeBackend))
         return;
 
@@ -186,7 +189,10 @@ static void InitForModule(const char* name)
     }
 
     globals::activeBackend = globals::Backend::None;
-    TryInitializeFrom(detected);
+    if (globals::preferredBackend != globals::Backend::None)
+        TryInitBackend(globals::preferredBackend);
+    else
+        TryInitializeFrom(detected);
 }
 
 // Hooked LoadLibraryA
@@ -272,7 +278,10 @@ static DWORD WINAPI onAttach(LPVOID lpParameter)
     }
 
     // Detect loaded rendering backends and initialize hooks accordingly
-    TryInitializeFrom(globals::Backend::Vulkan);
+    if (globals::preferredBackend != globals::Backend::None)
+        TryInitBackend(globals::preferredBackend);
+    else
+        TryInitializeFrom(globals::Backend::Vulkan);
 
     // Hook LoadLibraryA/W to catch backends loaded after injection
     HMODULE k32 = GetModuleHandleA("kernel32.dll");

--- a/globals.cpp
+++ b/globals.cpp
@@ -11,6 +11,8 @@ namespace globals {
     int openMenuKey = VK_INSERT;
     // Currently active rendering backend
     Backend activeBackend = Backend::None;
+    // Preferred backend to hook (None = auto fallback)
+    Backend preferredBackend = Backend::None;
     // Flag controlling runtime debug logging
     bool enableDebugLog = true;
 }
@@ -23,9 +25,9 @@ namespace globals {
 
 // Log initial global values for debugging
 static void LogGlobals() {
-    DebugLog("[Globals] mainModule=%p, mainWindow=%p, uninjectKey=0x%X, openMenuKey=0x%X, backend=%d\n",
+    DebugLog("[Globals] mainModule=%p, mainWindow=%p, uninjectKey=0x%X, openMenuKey=0x%X, activeBackend=%d, preferredBackend=%d\n",
         globals::mainModule, globals::mainWindow, globals::uninjectKey, globals::openMenuKey,
-        static_cast<int>(globals::activeBackend));
+        static_cast<int>(globals::activeBackend), static_cast<int>(globals::preferredBackend));
 }
 
 // Ensure we log when the DLL is loaded

--- a/namespaces.h
+++ b/namespaces.h
@@ -16,6 +16,8 @@ namespace globals {
                 Vulkan
         };
         extern Backend activeBackend;
+        // Preferred backend to hook. None means auto with fallback order
+        extern Backend preferredBackend;
         extern bool enableDebugLog;
         void SetDebugLogging(bool enable);
 }


### PR DESCRIPTION
## Summary
- allow specifying a preferred rendering backend via `globals::preferredBackend`
- skip automatic fallback when a preferred backend is set
- log chosen backend during initialization

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a5f071538c8324b675cbd9bdc8dc35