### PR TITLE
Capture only direct command queues in D3D12 hook

### DIFF
--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -436,12 +436,18 @@ namespace d3d12hook {
     }
 
     void STDMETHODCALLTYPE hookExecuteCommandListsD3D12(
-        ID3D12CommandQueue * _this,
+        ID3D12CommandQueue* _this,
         UINT                          NumCommandLists,
         ID3D12CommandList* const* ppCommandLists) {
         if (!gCommandQueue) {
-            gCommandQueue = _this;
-            DebugLog("[d3d12hook] Captured CommandQueue=%p\n", _this);
+            D3D12_COMMAND_QUEUE_DESC desc = _this->GetDesc();
+            DebugLog("[d3d12hook] CommandQueue type=%u\n", desc.Type);
+            if (desc.Type == D3D12_COMMAND_LIST_TYPE_DIRECT) {
+                gCommandQueue = _this;
+                DebugLog("[d3d12hook] Captured CommandQueue=%p\n", _this);
+            } else {
+                DebugLog("[d3d12hook] Skipping capture: non-direct queue\n");
+            }
         }
         oExecuteCommandListsD3D12(_this, NumCommandLists, ppCommandLists);
     }


### PR DESCRIPTION
## Summary
- Check command queue type before capturing in D3D12 hook
- Log detected command queue type for easier debugging

## Testing
- `msbuild Universal-ImGui-Hook.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a725062ca083248d800c43209ac9c7