### PR TITLE
Release D3D12 command queue before removing hooks

### DIFF
--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -571,6 +571,12 @@ HRESULT STDMETHODCALLTYPE hookSignalD3D12(
             gFenceEvent = nullptr;
         }
 
+        if (gCommandQueue)
+        {
+            gCommandQueue->Release();
+            gCommandQueue = nullptr;
+        }
+
         if (gDevice) gDevice->Release();
         delete[] gFrameContexts;
 


### PR DESCRIPTION
## Summary
- Release and null out the D3D12 command queue
- Ensure command queue is freed before hooks are removed

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `msbuild Universal-ImGui-Hook.sln /t:Build /p:Configuration=Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a727d4b7888324bebf10bd77b40a64