### PR TITLE
Call Signal directly in D3D12 present hooks

### DIFF
--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -221,9 +221,8 @@ namespace d3d12hook {
             else {
                 oExecuteCommandListsD3D12(gCommandQueue, 1, reinterpret_cast<ID3D12CommandList* const*>(&gCommandList));
                 if (gOverlayFence) {
-                    // Use the original Signal implementation so our hook does not
-                    // intercept the synchronization used for the internal overlay.
-                    HRESULT hr = oSignalD3D12(gCommandQueue, gOverlayFence, ++gOverlayFenceValue);
+                    // Call Signal directly on the command queue to synchronize the internal overlay.
+                    HRESULT hr = gCommandQueue->Signal(gOverlayFence, ++gOverlayFenceValue);
                     if (FAILED(hr)) {
                         LogHRESULT("Signal", hr);
                     }
@@ -422,9 +421,8 @@ namespace d3d12hook {
             else {
                 oExecuteCommandListsD3D12(gCommandQueue, 1, reinterpret_cast<ID3D12CommandList* const*>(&gCommandList));
                 if (gOverlayFence) {
-                    // Use the original Signal implementation so our hook does not
-                    // intercept the synchronization used for the internal overlay.
-                    HRESULT hr = oSignalD3D12(gCommandQueue, gOverlayFence, ++gOverlayFenceValue);
+                    // Call Signal directly on the command queue to synchronize the internal overlay.
+                    HRESULT hr = gCommandQueue->Signal(gOverlayFence, ++gOverlayFenceValue);
                     if (FAILED(hr)) {
                         LogHRESULT("Signal", hr);
                     }


### PR DESCRIPTION
## Summary
- call `Signal` directly on the D3D12 command queue for overlay fence synchronization in `hookPresentD3D12`
- apply the same `Signal` change in `hookPresent1D3D12`

## Testing
- `cmake .` *(fails: The source directory does not appear to contain CMakeLists.txt)*
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68a72a4ed2dc83248b29f09afcf890bb