### PR TITLE
Remove unused D3D12 Signal hook

### DIFF
--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -6,7 +6,6 @@ namespace d3d12hook {
     PresentD3D12            oPresentD3D12 = nullptr;
     Present1Fn              oPresent1D3D12 = nullptr;
     ExecuteCommandListsFn   oExecuteCommandListsD3D12 = nullptr;
-    SignalFn                oSignalD3D12 = nullptr;
     ResizeBuffersFn         oResizeBuffersD3D12 = nullptr;
 
     static ID3D12Device* gDevice = nullptr;
@@ -462,19 +461,6 @@ namespace d3d12hook {
             }
         }
         oExecuteCommandListsD3D12(_this, NumCommandLists, ppCommandLists);
-    }
-
-HRESULT STDMETHODCALLTYPE hookSignalD3D12(
-        ID3D12CommandQueue* _this,
-        ID3D12Fence*        pFence,
-        UINT64              Value)
-    {
-        // When we signal using our internal overlay fence, skip any capture logic
-        // by immediately calling the original Signal implementation.
-        if (pFence == gOverlayFence)
-            return oSignalD3D12(_this, pFence, Value);
-
-        return oSignalD3D12(_this, pFence, Value);
     }
 
     HRESULT STDMETHODCALLTYPE hookResizeBuffersD3D12(

--- a/namespaces.h
+++ b/namespaces.h
@@ -44,10 +44,6 @@ namespace d3d12hook {
 		ID3D12CommandQueue * _this, UINT NumCommandLists, ID3D12CommandList* const* ppCommandLists);
         extern ExecuteCommandListsFn oExecuteCommandListsD3D12;
 
-        typedef HRESULT(STDMETHODCALLTYPE* SignalFn)(
-                ID3D12CommandQueue * _this, ID3D12Fence* pFence, UINT64 Value);
-        extern SignalFn oSignalD3D12;
-
         typedef HRESULT(STDMETHODCALLTYPE* ResizeBuffersFn)(
                 IDXGISwapChain3* pSwapChain,
                 UINT BufferCount,
@@ -67,15 +63,10 @@ namespace d3d12hook {
 
         extern long __fastcall hookPresentD3D12(IDXGISwapChain3* pSwapChain, UINT SyncInterval, UINT Flags);
         extern long __fastcall hookPresent1D3D12(IDXGISwapChain3* pSwapChain, UINT SyncInterval, UINT Flags, const DXGI_PRESENT_PARAMETERS* pParams);
-	extern void STDMETHODCALLTYPE hookExecuteCommandListsD3D12(
-		ID3D12CommandQueue* _this,
-		UINT                          NumCommandLists,
-		ID3D12CommandList* const* ppCommandLists);
-
-        extern HRESULT STDMETHODCALLTYPE hookSignalD3D12(
+        extern void STDMETHODCALLTYPE hookExecuteCommandListsD3D12(
                 ID3D12CommandQueue* _this,
-                ID3D12Fence* pFence,
-                UINT64              Value);
+                UINT                          NumCommandLists,
+                ID3D12CommandList* const* ppCommandLists);
 
         extern void release();
         bool IsInitialized();


### PR DESCRIPTION
## Summary
- drop Signal hook creation and cleanup in `hooks.cpp`
- remove `hookSignalD3D12` and `oSignalD3D12` declarations and implementation

## Testing
- `g++ -std=c++20 -c hooks.cpp` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a72c41c3708324a33253ffe45ecec1