### PR TITLE
Handle D3D12 device lost on Signal failure

### DIFF
--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -28,6 +28,8 @@ namespace d3d12hook {
     static bool                   gShutdown = false;
     static bool                   gAfterFirstPresent = false;
 
+    void release();
+
     // Utility to log HRESULTs
     inline void LogHRESULT(const char* label, HRESULT hr) {
         DebugLog("[d3d12hook] %s: hr=0x%08X\n", label, hr);
@@ -231,6 +233,14 @@ namespace d3d12hook {
                     HRESULT hr = gCommandQueue->Signal(gOverlayFence, ++gOverlayFenceValue);
                     if (FAILED(hr)) {
                         LogHRESULT("Signal", hr);
+                        if (gDevice) {
+                            HRESULT reason = gDevice->GetDeviceRemovedReason();
+                            DebugLog("[d3d12hook] DeviceRemovedReason=0x%08X\n", reason);
+                            if (reason != S_OK) {
+                                DebugLog("[d3d12hook] Device lost. Releasing resources.\n");
+                                release();
+                            }
+                        }
                     }
                 }
             }
@@ -437,6 +447,14 @@ namespace d3d12hook {
                     HRESULT hr = gCommandQueue->Signal(gOverlayFence, ++gOverlayFenceValue);
                     if (FAILED(hr)) {
                         LogHRESULT("Signal", hr);
+                        if (gDevice) {
+                            HRESULT reason = gDevice->GetDeviceRemovedReason();
+                            DebugLog("[d3d12hook] DeviceRemovedReason=0x%08X\n", reason);
+                            if (reason != S_OK) {
+                                DebugLog("[d3d12hook] Device lost. Releasing resources.\n");
+                                release();
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- log D3D12 device removal reason when queue Signal fails
- release hooks/resources when device is lost

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a7301c04f0832494ed55193442d1fb