### PR TITLE
Guard D3D12 ImGui teardown

### DIFF
--- a/d3d12hook.cpp
+++ b/d3d12hook.cpp
@@ -573,9 +573,13 @@ namespace d3d12hook {
         }
 
         // Shutdown ImGui before releasing any D3D resources
-        ImGui_ImplDX12_Shutdown();
-        ImGui_ImplWin32_Shutdown();
-        ImGui::DestroyContext();
+        if (gInitialized && ImGui::GetCurrentContext())
+        {
+            ImGui_ImplDX12_Shutdown();
+            ImGui_ImplWin32_Shutdown();
+            ImGui::DestroyContext();
+            gInitialized = false;
+        }
 
         if (gCommandList) gCommandList->Release();
         if (gHeapRTV) gHeapRTV->Release();


### PR DESCRIPTION
## Summary
- Avoid double releasing ImGui in the D3D12 hook by checking context and initialization flag

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a733c803848324bd04980e86513f33