### PR TITLE
Handle Win32 input only when menu is open

### DIFF
--- a/inputhooks.cpp
+++ b/inputhooks.cpp
@@ -46,14 +46,15 @@ namespace inputhook {
 
     LRESULT APIENTRY WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
-        ImGuiIO& io = ImGui::GetIO();
-
-        ImGui_ImplWin32_WndProcHandler(hwnd, uMsg, wParam, lParam);
-
-        if (menu::isOpen && (io.WantCaptureMouse || io.WantCaptureKeyboard))
+        if (menu::isOpen)
         {
-            //DebugLog("[inputhook] Swallow msg=0x%X (WantCapture M=%d K=%d)\n", uMsg, io.WantCaptureMouse, io.WantCaptureKeyboard);
-            return TRUE;
+            ImGui_ImplWin32_WndProcHandler(hwnd, uMsg, wParam, lParam);
+            ImGuiIO& io = ImGui::GetIO();
+            if (io.WantCaptureMouse || io.WantCaptureKeyboard)
+            {
+                //DebugLog("[inputhook] Swallow msg=0x%X (WantCapture M=%d K=%d)\n", uMsg, io.WantCaptureMouse, io.WantCaptureKeyboard);
+                return TRUE;
+            }
         }
 
         return CallWindowProc(sOriginalWndProc, hwnd, uMsg, wParam, lParam);

--- a/menu.cpp
+++ b/menu.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 
 namespace menu {
-    bool isOpen = true;
+    bool isOpen = false;
     float test = 0.0f;
     static bool noTitleBar = false;
 


### PR DESCRIPTION
## Summary
- Invoke `ImGui_ImplWin32_WndProcHandler` only while the in-game menu is open and swallow messages when ImGui requests mouse or keyboard capture
- Start with the menu closed to avoid blocking game input on launch

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `g++ -c inputhooks.cpp -o /tmp/inputhooks.o` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a73decf1d483249371edb9173754d6