### PR TITLE
Add cursor confinement hooks

### DIFF
--- a/Universal-ImGui-Hook.vcxproj
+++ b/Universal-ImGui-Hook.vcxproj
@@ -140,6 +140,7 @@
     <ClCompile Include="imgui\imgui_widgets.cpp" />
     <ClCompile Include="inputhooks.cpp" />
     <ClCompile Include="menu.cpp" />
+    <ClCompile Include="mousehooks.cpp" />
     <ClCompile Include="vulkanhook.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/Universal-ImGui-Hook.vcxproj.filters
+++ b/Universal-ImGui-Hook.vcxproj.filters
@@ -63,6 +63,9 @@
     <ClCompile Include="menu.cpp">
       <Filter>Sources Files</Filter>
     </ClCompile>
+    <ClCompile Include="mousehooks.cpp">
+      <Filter>Sources Files</Filter>
+    </ClCompile>
     <ClCompile Include="globals.cpp">
       <Filter>Sources Files</Filter>
     </ClCompile>

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 #include <cstring>
 
+namespace mousehooks { void Init(); void Remove(); }
+
 // Utility helpers for backend initialization checks
 using IsInitFn = bool (*)();
 
@@ -243,6 +245,8 @@ static DWORD WINAPI UninjectThread(LPVOID)
         break;
     }
 
+    mousehooks::Remove();
+
     // Disable and remove all hooks, then uninitialize MinHook
     MH_DisableHook(MH_ALL_HOOKS);
     MH_RemoveHook(MH_ALL_HOOKS);
@@ -300,6 +304,8 @@ static DWORD WINAPI onAttach(LPVOID lpParameter)
         }
     }
 
+    mousehooks::Init();
+
     DebugLog("[DllMain] Hook initialization completed.\n");
     return 0;
 }
@@ -345,6 +351,7 @@ BOOL WINAPI DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved
         default:
             break;
         }
+        mousehooks::Remove();
         MH_DisableHook(MH_ALL_HOOKS);
         MH_RemoveHook(MH_ALL_HOOKS);
         MH_Uninitialize();

--- a/mousehooks.cpp
+++ b/mousehooks.cpp
@@ -1,0 +1,52 @@
+#include "stdafx.h"
+
+using SetCursorPos_t = BOOL (WINAPI*)(int,int);
+static SetCursorPos_t oSetCursorPos = nullptr;
+BOOL WINAPI hookSetCursorPos(int x,int y) {
+    return menu::isOpen ? TRUE : oSetCursorPos(x,y);
+}
+
+using ClipCursor_t = BOOL (WINAPI*)(const RECT*);
+static ClipCursor_t oClipCursor = nullptr;
+BOOL WINAPI hookClipCursor(const RECT* rect) {
+    return menu::isOpen ? TRUE : oClipCursor(rect);
+}
+
+namespace mousehooks {
+    void Init() {
+        HMODULE user32 = GetModuleHandleA("user32.dll");
+        if (!user32)
+            return;
+
+        if (auto addr = GetProcAddress(user32, "SetCursorPos")) {
+            if (MH_CreateHook(addr, reinterpret_cast<LPVOID>(hookSetCursorPos), reinterpret_cast<LPVOID*>(&oSetCursorPos)) == MH_OK) {
+                MH_EnableHook(addr);
+                DebugLog("[mousehooks] Hooked SetCursorPos@%p\n", addr);
+            }
+        }
+
+        if (auto addr = GetProcAddress(user32, "ClipCursor")) {
+            if (MH_CreateHook(addr, reinterpret_cast<LPVOID>(hookClipCursor), reinterpret_cast<LPVOID*>(&oClipCursor)) == MH_OK) {
+                MH_EnableHook(addr);
+                DebugLog("[mousehooks] Hooked ClipCursor@%p\n", addr);
+            }
+        }
+    }
+
+    void Remove() {
+        HMODULE user32 = GetModuleHandleA("user32.dll");
+        if (!user32)
+            return;
+
+        if (auto addr = GetProcAddress(user32, "SetCursorPos")) {
+            MH_DisableHook(addr);
+            MH_RemoveHook(addr);
+        }
+
+        if (auto addr = GetProcAddress(user32, "ClipCursor")) {
+            MH_DisableHook(addr);
+            MH_RemoveHook(addr);
+        }
+    }
+}
+

--- a/namespaces.h
+++ b/namespaces.h
@@ -27,9 +27,14 @@ namespace hooks {
 }
 
 namespace inputhook {
-	extern void Init(HWND hWindow);
-	extern void Remove(HWND hWindow);
-	static LRESULT APIENTRY WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+        extern void Init(HWND hWindow);
+        extern void Remove(HWND hWindow);
+        static LRESULT APIENTRY WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+}
+
+namespace mousehooks {
+        void Init();
+        void Remove();
 }
 
 namespace d3d12hook {


### PR DESCRIPTION
## Summary
- intercept SetCursorPos and ClipCursor with MinHook and bypass them while the menu is open
- initialize and remove mouse hooks during DLL attach/detach
- include mousehooks.cpp in the Visual Studio project

## Testing
- `g++ -std=c++17 -c mousehooks.cpp -o /tmp/mousehooks.o` *(fails: windows.h missing)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74af7d070832485aa88dcdaaf530f