### PR TITLE
Handle ImGui input releases

### DIFF
--- a/inputhooks.cpp
+++ b/inputhooks.cpp
@@ -52,8 +52,18 @@ namespace inputhook {
             ImGuiIO& io = ImGui::GetIO();
             if (io.WantCaptureMouse || io.WantCaptureKeyboard)
             {
-                //DebugLog("[inputhook] Swallow msg=0x%X (WantCapture M=%d K=%d)\n", uMsg, io.WantCaptureMouse, io.WantCaptureKeyboard);
-                return TRUE;
+                switch (uMsg)
+                {
+                case WM_KEYUP:
+                case WM_SYSKEYUP:
+                case WM_LBUTTONUP:
+                case WM_RBUTTONUP:
+                case WM_MBUTTONUP:
+                case WM_XBUTTONUP:
+                    return CallWindowProc(sOriginalWndProc, hwnd, uMsg, wParam, lParam);
+                default:
+                    return TRUE; // on bloque seulement les pressions
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Propagate key and mouse button release messages to the original window procedure when ImGui captures input
- Block only input press events while menu is open

## Testing
- `g++ -c inputhooks.cpp` *(fails: windows.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74dd288ec8324966047c500aa7c48