### PR TITLE
Add Vulkan proc address hooks for late initialization

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -13,7 +13,7 @@ static bool WaitForInitialization(IsInitFn fn, int attempts = 50, int sleepMs = 
             return true;
         Sleep(sleepMs);
     }
-    return fn();
+    return false;
 }
 
 static bool TryInitBackend(globals::Backend backend)
@@ -31,8 +31,7 @@ static bool TryInitBackend(globals::Backend backend)
                 globals::activeBackend = globals::Backend::Vulkan;
                 return true;
             }
-            DebugLog("[DllMain] Vulkan initialization failed, falling back.\n");
-            hooks_vk::release();
+            DebugLog("[DllMain] Vulkan initialization pending, hooks remain active.\n");
         }
         break;
     case globals::Backend::DX12:


### PR DESCRIPTION
## Summary
- hook `vkGetDeviceProcAddr`/`vkGetInstanceProcAddr` to install `vkQueuePresentKHR` even after device creation
- keep Vulkan hooks active until `vkQueuePresentKHR` fires and mark backend initialized
- adjust cleanup and initialization to manage new hooks

## Testing
- `g++ -std=c++17 -c vulkanhook.cpp -o /tmp/vulkanhook.o` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a89383f43c832486ac5868f67443d8