### PR TITLE
Skip device scan when GetDeviceProcAddr missing

### DIFF
--- a/vulkanhook.cpp
+++ b/vulkanhook.cpp
@@ -627,6 +627,12 @@ namespace hooks_vk {
                 if (!oGetDeviceProcAddr)
                     oGetDeviceProcAddr = getDeviceProcAddr;
 
+                if (!oGetDeviceProcAddr)
+                {
+                    DebugLog("[vulkanhook] skipping device scan; GetDeviceProcAddr unresolved\n");
+                    return oQueuePresentKHR(queue, pPresentInfo);
+                }
+
                 VkDevice        found_device = VK_NULL_HANDLE;
                 void**          queue_ptr    = reinterpret_cast<void**>(queue);
                 if (queue_ptr)


### PR DESCRIPTION
## Summary
- guard against unresolved GetDeviceProcAddr in vkQueuePresentKHR to avoid invalid device scans

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e3fd5c8c83249efec7fab20966fe